### PR TITLE
do not explicitly check for map name

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4216,19 +4216,6 @@ public:
 void CServer::OnRoundEnd()
 {
 #ifdef CONF_SQL
-	if(
-		str_comp(m_aCurrentMap, "infc_lunaroutpost") != 0 &&
-		str_comp(m_aCurrentMap, "infc_skull") != 0 &&
-		str_comp(m_aCurrentMap, "infc_warehouse") != 0 &&
-		str_comp(m_aCurrentMap, "infc_damascus") != 0 &&
-		str_comp(m_aCurrentMap, "infc_eidalfitr") != 0 &&
-		str_comp(m_aCurrentMap, "infc_newdust") != 0 &&
-		str_comp(m_aCurrentMap, "infc_hardcorepit") != 0 &&
-		str_comp(m_aCurrentMap, "infc_normandie") != 0 &&
-		str_comp(m_aCurrentMap, "infc_deathdealer") != 0
-	)
-		return;
-	
 	//Send round statistics
 	CSqlJob* pRoundJob = new CSqlJob_Server_SendRoundStatistics(this, RoundStatistics(), m_aCurrentMap);
 	pRoundJob->Start();


### PR DESCRIPTION
I don't understand why we list maps this way. What is the reason for that? Lets just write stats for any map that we have