### PR TITLE
Log human/zombie wins and player chosen classes

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -59,8 +59,9 @@ CInputCount CountInput(int Prev, int Cur)
 MACRO_ALLOC_POOL_ID_IMPL(CCharacter, MAX_CLIENTS)
 
 // Character, "physical" player's part
-CCharacter::CCharacter(CGameWorld *pWorld)
-: CEntity(pWorld, CGameWorld::ENTTYPE_CHARACTER)
+CCharacter::CCharacter(CGameWorld *pWorld, IConsole *pConsole)
+: CEntity(pWorld, CGameWorld::ENTTYPE_CHARACTER),
+m_pConsole(pConsole)
 {
 	m_ProximityRadius = ms_PhysSize;
 	m_Health = 0;
@@ -1947,6 +1948,9 @@ void CCharacter::Tick()
 					m_pPlayer->SetClass(NewClass);
 					m_pPlayer->SetOldClass(NewClass);
 					
+					char aBuf[256];
+					str_format(aBuf, sizeof(aBuf), "choose_class player='%s' class='%d'", Server()->ClientName(m_pPlayer->GetCID()), NewClass);
+					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
 					if(Bonus)
 						IncreaseArmor(10);
 				}

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -40,13 +40,17 @@ enum
 
 class CCharacter : public CEntity
 {
+	class IConsole *m_pConsole;
+
 	MACRO_ALLOC_POOL_ID()
 
 public:
+	class IConsole *Console() { return m_pConsole; }
+
 	//character's size
 	static const int ms_PhysSize = 28;
 
-	CCharacter(CGameWorld *pWorld);
+	CCharacter(CGameWorld *pWorld, IConsole *pConsole);
 
 	virtual void Reset();
 	virtual void Destroy();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1365,6 +1365,11 @@ void CGameContext::OnClientDrop(int ClientID, int Type, const char *pReason)
 	}
 	// InfClassR remove spectators
 	RemoveSpectatorCID(ClientID);
+
+	char aBuf[256];
+	str_format(aBuf, sizeof(aBuf), "leave player='%d:%s'", ClientID, Server()->ClientName(ClientID));
+	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+
 	// InfClassR end
 }
 

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -297,6 +297,10 @@ void CGameControllerMOD::Tick()
 			
 			GameServer()->SendChatTarget_Localization(-1, CHATCATEGORY_INFECTED, _("Infected won the round in {sec:RoundDuration}"), "RoundDuration", &Seconds, NULL);
 			
+			char aBuf[512];
+			str_format(aBuf, sizeof(aBuf), "round_end infected won");
+			GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
 			EndRound();
 		}
 		
@@ -384,6 +388,10 @@ void CGameControllerMOD::Tick()
 				{
 					GameServer()->SendChatTarget_Localization_P(-1, CHATCATEGORY_HUMANS, NumHumans, _P("One human won the round", "{int:NumHumans} humans won the round"), "NumHumans", &NumHumans, NULL);
 					
+					char aBuf[512];
+					str_format(aBuf, sizeof(aBuf), "round_end human won");
+					GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
 					CPlayerIterator<PLAYERITER_INGAME> Iter(GameServer()->m_apPlayers);
 					while(Iter.Next())
 					{

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -549,7 +549,7 @@ void CPlayer::TryRespawn()
 /* INFECTION MODIFICATION END *****************************************/
 
 	m_Spawning = false;
-	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World);
+	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World, GameServer()->Console());
 	m_pCharacter->Spawn(this, SpawnPos);
 	if(GetClass() != PLAYERCLASS_NONE)
 		GameServer()->CreatePlayerSpawn(SpawnPos);


### PR DESCRIPTION
This should simply add additional console logging statements to track player decisions.

If you were interested in tracking and displaying stats (via web) these changes would be required
to get https://github.com/resamvi/infclass-stats to work properly. You can see a demo running at https://stats.resamvi.de/#/. The corresponding infclass test server (with these changes already applied) is running on "Armadillo's Test Infectionclass"