### PR TITLE
Fixes to previous logs

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2376,11 +2376,9 @@ void CCharacter::Die(int Killer, int Weapon)
 	int ModeSpecial = GameServer()->m_pController->OnCharacterDeath(this, GameServer()->m_apPlayers[Killer], Weapon);
 
 	char aBuf[256];
-	CPlayer* killerPlayer = GameServer()->m_apPlayers[Killer];
-	str_format(aBuf, sizeof(aBuf), "kill killer='%d:%s' victim='%d:%s' weapon=%d special=%d killer_is_zombie='%d'",
+	str_format(aBuf, sizeof(aBuf), "kill killer='%d:%s' victim='%d:%s' weapon=%d special=%d",
 		Killer, Server()->ClientName(Killer),
-		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial, 
-		killerPlayer->IsInfected());
+		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1948,9 +1948,12 @@ void CCharacter::Tick()
 					m_pPlayer->SetClass(NewClass);
 					m_pPlayer->SetOldClass(NewClass);
 					
+					// class '11' counts as picking "Random"
 					char aBuf[256];
-					str_format(aBuf, sizeof(aBuf), "choose_class player='%s' class='%d'", Server()->ClientName(m_pPlayer->GetCID()), NewClass);
+					const char *format = Bonus ? "choose_class player='%s' class='11'" : "choose_class player='%s' class='%d'";
+					str_format(aBuf, sizeof(aBuf), format, Server()->ClientName(m_pPlayer->GetCID()));
 					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
+					
 					if(Bonus)
 						IncreaseArmor(10);
 				}
@@ -2373,9 +2376,11 @@ void CCharacter::Die(int Killer, int Weapon)
 	int ModeSpecial = GameServer()->m_pController->OnCharacterDeath(this, GameServer()->m_apPlayers[Killer], Weapon);
 
 	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "kill killer='%d:%s' victim='%d:%s' weapon=%d special=%d",
+	CPlayer* killerPlayer = GameServer()->m_apPlayers[Killer];
+	str_format(aBuf, sizeof(aBuf), "kill killer='%d:%s' victim='%d:%s' weapon=%d special=%d killer_is_zombie='%d'",
 		Killer, Server()->ClientName(Killer),
-		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial);
+		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial, 
+		killerPlayer->IsInfected());
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -298,7 +298,7 @@ void CGameControllerMOD::Tick()
 			GameServer()->SendChatTarget_Localization(-1, CHATCATEGORY_INFECTED, _("Infected won the round in {sec:RoundDuration}"), "RoundDuration", &Seconds, NULL);
 			
 			char aBuf[512];
-			str_format(aBuf, sizeof(aBuf), "round_end infected won");
+			str_format(aBuf, sizeof(aBuf), "round_end winner='zombies' survivors='0' duration='%d' round='%d of %d'", Seconds, m_RoundCount+1, g_Config.m_SvRoundsPerMap);
 			GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 			EndRound();
@@ -389,7 +389,8 @@ void CGameControllerMOD::Tick()
 					GameServer()->SendChatTarget_Localization_P(-1, CHATCATEGORY_HUMANS, NumHumans, _P("One human won the round", "{int:NumHumans} humans won the round"), "NumHumans", &NumHumans, NULL);
 					
 					char aBuf[512];
-					str_format(aBuf, sizeof(aBuf), "round_end human won");
+					int Seconds = (Server()->Tick()-m_RoundStartTick)/((float)Server()->TickSpeed());
+					str_format(aBuf, sizeof(aBuf), "round_end winner='humans' survivors='%d' duration='%d' round='%d of %d'", NumHumans, Seconds, m_RoundCount+1, g_Config.m_SvRoundsPerMap);
 					GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 					CPlayerIterator<PLAYERITER_INGAME> Iter(GameServer()->m_apPlayers);
@@ -838,7 +839,7 @@ int CGameControllerMOD::ChooseInfectedClass(CPlayer* pPlayer)
 	int nbInfected = 0;
 	bool thereIsAWitch = false;
 	bool thereIsAnUndead = false;
-	
+
 	CPlayerIterator<PLAYERITER_INGAME> Iter(GameServer()->m_apPlayers);
 	while(Iter.Next())
 	{
@@ -882,6 +883,12 @@ int CGameControllerMOD::ChooseInfectedClass(CPlayer* pPlayer)
         (Server()->GetClassAvailability(PLAYERCLASS_UNDEAD) && nbInfected > 2 && !thereIsAnUndead) ?
         (double) g_Config.m_InfProbaUndead : 0.0f;
 	
+	int Seconds = (Server()->Tick()-m_RoundStartTick)/((float)Server()->TickSpeed());
+	char aBuf[256];
+	str_format(aBuf, sizeof(aBuf), "infected victim='%s' duration='%d'", 
+		Server()->ClientName(pPlayer->GetCID()), Seconds);
+	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
 	return START_INFECTEDCLASS + 1 + random_distribution(Probability, Probability + NB_INFECTEDCLASS);
 }
 


### PR DESCRIPTION
* Mercenary up to biologist have enum number 2 to 10. It prints 11 for "Random" picks -> So I'm able to record random picks
* On each round end give more details (duration, survivors, round number)
* Record event when human got infected and when he got infected