### PR TITLE
Can someone test this before merging in

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3005,7 +3005,14 @@ public:
 					int UserLevel = (int)pSqlServer->GetResults()->getInt("Level");
 					m_pServer->m_aClients[m_ClientID].m_UserID = UserID;
 					m_pServer->m_aClients[m_ClientID].m_UserLevel = UserLevel;
+					
+					char aOldName[MAX_NAME_LENGTH];
+					str_copy(aOldName, Server()->ClientName(ClientID), sizeof(aOldName));
 					str_copy(m_pServer->m_aClients[m_ClientID].m_aUsername, m_sName.Str(), sizeof(m_pServer->m_aClients[m_ClientID].m_aUsername));
+
+					char aBuf[256];
+					str_format(aBuf, sizeof(aBuf), "change_name previous='%s' now='%s'", aOldName, m_pServer->m_aClients[m_ClientID].m_aUsername);
+					Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 					
 					//If we are really unlucky, the client can deconnect and another one connect during this small code
 					if(m_pServer->m_aClients[m_ClientID].m_LogInstance != GetInstance())


### PR DESCRIPTION
When a user logs in, the console should display for example 
`"change_name previous='Water Malone' now='water'"`

I can't test it though because login/register does not work on my test server