### PR TITLE
added min-rounds-for-map-vote option

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -55,6 +55,7 @@ MACRO_CONFIG_INT(InfAccusationThreshold, inf_accusation_threshold, 4, 0, 8, CFGF
 MACRO_CONFIG_INT(InfLeaverBanTime, inf_leaver_ban_time, 5, 0, 180, CFGFLAG_SERVER, "How long an infected gets banned (in minutes), when leaving and leaving causes a human to get infected")
 MACRO_CONFIG_INT(InfFastDownload, inf_fast_download, 1, 0, 1, CFGFLAG_SERVER, "Enables fast download of maps")
 MACRO_CONFIG_INT(InfMapWindow, inf_map_window, 15, 0, 100, CFGFLAG_SERVER, "Map downloading send-ahead window")
+MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_for_map_vote, 1, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
 MACRO_CONFIG_INT(InfConWaitingTime, inf_con_waiting_time, 1, 0, 60, CFGFLAG_SERVER, "Number of seconds to wait before enter the game")
 MACRO_CONFIG_INT(InfCaptcha, inf_captcha, 0, 0, 1, CFGFLAG_SERVER, "Enable captcha")
 MACRO_CONFIG_INT(InfDefenderLimit, inf_defender_limit, 40, 0, 64, CFGFLAG_SERVER, "Maximum number of defenders in game")

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1551,6 +1551,14 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					return;
 				}
 
+				if (g_Config.m_InfMinRoundsForMapVote > m_pController->GetRoundCount())
+				{
+					char aBufVoteMap[128];
+					str_format(aBufVoteMap, sizeof(aBufVoteMap), "Each map must be played atleast %i rounds before calling a map vote", g_Config.m_InfMinRoundsForMapVote);
+					SendChatTarget(ClientID, aBufVoteMap);
+					return;
+				}
+
 				if(!m_pController->CanVote())
 				{
 					SendChatTarget(ClientID, "Votes are only allowed when the round start.");

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1554,7 +1554,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				if (g_Config.m_InfMinRoundsForMapVote > m_pController->GetRoundCount())
 				{
 					char aBufVoteMap[128];
-					str_format(aBufVoteMap, sizeof(aBufVoteMap), "Each map must be played atleast %i rounds before calling a map vote", g_Config.m_InfMinRoundsForMapVote);
+					str_format(aBufVoteMap, sizeof(aBufVoteMap), "Each map must be played at least %i rounds before calling a map vote", g_Config.m_InfMinRoundsForMapVote);
 					SendChatTarget(ClientID, aBufVoteMap);
 					return;
 				}

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -123,6 +123,10 @@ const char *IGameController::GetTeamName(int Team)
 
 static bool IsSeparator(char c) { return c == ';' || c == ' ' || c == ',' || c == '\t'; }
 
+int IGameController::GetRoundCount() {
+	return m_RoundCount;
+}
+
 void IGameController::StartRound()
 {
 	ResetGame();

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -78,6 +78,7 @@ public:
 	void StartRound();
 	virtual void EndRound();
 	void ChangeMap(const char *pToMap);
+	int GetRoundCount();
 
 	bool IsFriendlyFire(int ClientID1, int ClientID2);
 


### PR DESCRIPTION
This allows to define a config var that forces players to play at least X rounds before voting for a new map.
If it is set to 1, an example: A new map got voted -> Server changes map -> One player wants to instantly vote for a new map -> Player gets denied with the message: "Each map must be played at least 1 round before calling a map vote"
This can be disabled by setting the config var to 0.

The default value is set to 1, but i can also set it to 0, so it is disabled on default