### PR TITLE
add short laser wall flicker

### DIFF
--- a/src/game/server/entities/engineer-wall.cpp
+++ b/src/game/server/entities/engineer-wall.cpp
@@ -24,6 +24,7 @@ CEngineerWall::CEngineerWall(CGameWorld *pGameWorld, vec2 Pos1, vec2 Pos2, int O
 	m_LifeSpan = Server()->TickSpeed()*g_Config.m_InfBarrierLifeSpan;
 	GameWorld()->InsertEntity(this);
 	m_EndPointID = Server()->SnapNewID();
+	m_WallFlashTicks = 0;
 }
 
 CEngineerWall::~CEngineerWall()
@@ -39,6 +40,9 @@ void CEngineerWall::Reset()
 void CEngineerWall::Tick()
 {
 	if(m_MarkedForDestroy) return;
+
+	if (m_WallFlashTicks > 0) 
+		m_WallFlashTicks--;
 
 	m_LifeSpan--;
 	
@@ -59,6 +63,7 @@ void CEngineerWall::Tick()
 			{
 				if(p->GetPlayer())
 				{
+					m_WallFlashTicks = 10;
 					for(CCharacter *pHook = (CCharacter*) GameWorld()->FindFirst(CGameWorld::ENTTYPE_CHARACTER); pHook; pHook = (CCharacter *)pHook->TypeNext())
 					{
 						if(
@@ -107,7 +112,9 @@ void CEngineerWall::Snap(int SnappingClient)
 
 	// Laser dieing animation
 	int LifeDiff = 0;
-	if (m_LifeSpan < 1*Server()->TickSpeed())
+	if (m_WallFlashTicks > 0) // flash laser for a few ticks when zombie jumps
+		LifeDiff = 5;
+	else if (m_LifeSpan < 1*Server()->TickSpeed())
 		LifeDiff = random_int(4, 5);
 	else if (m_LifeSpan < 2*Server()->TickSpeed())
 		LifeDiff = random_int(3, 5);

--- a/src/game/server/entities/engineer-wall.cpp
+++ b/src/game/server/entities/engineer-wall.cpp
@@ -63,7 +63,6 @@ void CEngineerWall::Tick()
 			{
 				if(p->GetPlayer())
 				{
-					m_WallFlashTicks = 10;
 					for(CCharacter *pHook = (CCharacter*) GameWorld()->FindFirst(CGameWorld::ENTTYPE_CHARACTER); pHook; pHook = (CCharacter *)pHook->TypeNext())
 					{
 						if(
@@ -83,6 +82,7 @@ void CEngineerWall::Tick()
 					if(p->GetClass() != PLAYERCLASS_UNDEAD)
 					{
 						int LifeSpanReducer = ((Server()->TickSpeed()*g_Config.m_InfBarrierTimeReduce)/100);
+						m_WallFlashTicks = 10;
 						
 						if(p->GetClass() == PLAYERCLASS_GHOUL)
 						{

--- a/src/game/server/entities/engineer-wall.h
+++ b/src/game/server/entities/engineer-wall.h
@@ -24,6 +24,7 @@ private:
 	vec2 m_Pos2;
 	int m_LifeSpan;
 	int m_EndPointID;
+	int m_WallFlashTicks;
 };
 
 #endif


### PR DESCRIPTION
If a zombie jumps into a laser wall of an engineer, the wall will flicker for a very short time.
This is to indicate that the time of the wall was reduced.
This commit has only a visual effect.