### PR TITLE
voodoos do not destroy mines when in voodoo mode

### DIFF
--- a/src/game/server/entities/biologist-mine.cpp
+++ b/src/game/server/entities/biologist-mine.cpp
@@ -91,6 +91,8 @@ void CBiologistMine::Tick()
 	for(CCharacter *p = (CCharacter*) GameWorld()->FindFirst(CGameWorld::ENTTYPE_CHARACTER); p; p = (CCharacter *)p->TypeNext())
 	{
 		if(!p->IsInfected()) continue;
+		if(p->GetClass() == PLAYERCLASS_UNDEAD && p->IsFrozen()) continue;
+		if(p->GetClass() == PLAYERCLASS_VOODOO && p->m_VoodooAboutToDie) continue;
 
 		vec2 IntersectPos = closest_point_on_line(m_Pos, m_EndPos, p->m_Pos);
 		float Len = distance(p->m_Pos, IntersectPos);

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -198,7 +198,6 @@ private:
 	vec2 m_SpawnPosition;
 
 	int m_VoodooTimeAlive;
-	bool m_VoodooAboutToDie;
 	int m_VoodooKiller; // Save killer + weapon for delayed kill message
 	int m_VoodooWeapon;
 public:
@@ -222,6 +221,7 @@ public:
 	int m_NinjaStrengthBuff;
 	int m_NinjaAmmoBuff;
 	int m_RefreshTime;
+	bool m_VoodooAboutToDie;
 	
 
 public:

--- a/src/game/server/entities/merc-bomb.cpp
+++ b/src/game/server/entities/merc-bomb.cpp
@@ -53,6 +53,7 @@ void CMercenaryBomb::Tick()
 	{
 		if(!p->IsInfected()) continue;
 		if(p->GetClass() == PLAYERCLASS_UNDEAD && p->IsFrozen()) continue;
+		if(p->GetClass() == PLAYERCLASS_VOODOO && p->m_VoodooAboutToDie) continue;
 
 		float Len = distance(p->m_Pos, m_Pos);
 		if(Len < p->m_ProximityRadius+80.0f)

--- a/src/game/server/entities/scientist-mine.cpp
+++ b/src/game/server/entities/scientist-mine.cpp
@@ -119,6 +119,7 @@ void CScientistMine::Tick()
 	{
 		if(!p->IsInfected()) continue;
 		if(p->GetClass() == PLAYERCLASS_UNDEAD && p->IsFrozen()) continue;
+		if(p->GetClass() == PLAYERCLASS_VOODOO && p->m_VoodooAboutToDie) continue;
 
 		float Len = distance(p->m_Pos, m_Pos);
 		if(Len < p->m_ProximityRadius+g_Config.m_InfMineRadius)


### PR DESCRIPTION
Voodoo class was intended to work like the undead / only destroy scientist mines while being alive.
Right now a voodoo can clear all scientist mines, biologist mines and merc bombs while in voodoo mode.
This change will fix this and will only allow voodoos to destroy mines while not in voodoo mode.