### PR TITLE
infection zone starts working when infection started

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1643,7 +1643,7 @@ void CCharacter::Tick()
 		{
 			Die(m_pPlayer->GetCID(), WEAPON_WORLD);
 		}
-		else if(m_Alive && (Index0 == ZONE_DAMAGE_INFECTION || Index1 == ZONE_DAMAGE_INFECTION || Index2 == ZONE_DAMAGE_INFECTION || Index3 == ZONE_DAMAGE_INFECTION))
+		else if(m_Alive && (Index0 == ZONE_DAMAGE_INFECTION || Index1 == ZONE_DAMAGE_INFECTION || Index2 == ZONE_DAMAGE_INFECTION || Index3 == ZONE_DAMAGE_INFECTION) && GameServer()->m_pController->IsInfectionStarted())
 		{
 			if(IsInfected())
 			{


### PR DESCRIPTION
Recently breton made a commit which prevents zombies from harming humans in the first 5 sec of the game (while people are still choosing their race). But humans can still jump into the infection zone and then pull humans inside to make them zombies.
So i suggest to add this commit as well which will prevent humans from getting zombies inside the infection zone for the first 5 sec, until the random zombies are chosen.