### PR TITLE
map_vote_rotation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,26 @@ Slightly modified version of original [InfClass by necropotame](https://github.c
 ```bash
 sudo apt install libmaxminddb-dev
 ```
+## Config variables
+The variables are defined here:<br/>
+[config_variables.h](src/engine/shared/config_variables.h)<br/>
+[variable.h](src/game/variables.h)<br/>
+You can type these commands inside the rcon console (F2) or <br/>
+you can also put them into a file called autoexec.cfg which should be next to your server binary.
+
 ## Maps
 You can create new maps with [TeeUniverse](https://github.com/teeuniverse/teeuniverse)
 
+### .mapinfo
+You can create a map info file with the same name as the map and put it next to it. (e.g. "infc_skull.mapinfo")<br/>
+Inside this file you can define 2 variables:<br/>
+```timelimit x```<br/>
+x is the number of minutes a round should take on this map.<br/>
+```minplayers x```<br/>
+x is the minimum number of players this map should be played on, this has an impact on the map rotation.<br/>
+If there are not enough players the server will skip this map. (But you can still vote and play on it)
+
 ### Map commands
-You can type these commands inside the rcon console (F2) or <br/>
-you can also put them into a file called autoexec.cfg which should be next to your server binary.
 
 With ```sv_maprotation``` you can define what maps will be played in which order, for example:<br/>
 ```sv_maprotation "infc_skull infc_warehouse infc_damascus"```<br/>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ If there are not enough players the server will skip this map. (But you can stil
 
 With ```sv_maprotation``` you can define what maps will be played in which order, for example:<br/>
 ```sv_maprotation "infc_skull infc_warehouse infc_damascus"```<br/>
-With ```sv_rounds_per_map``` you can define how many rounds each map should be played before changing to the next map.
+With ```sv_rounds_per_map``` you can define how many rounds each map should be played before changing to the next map.<br/>
+If ```inf_maprotation_random``` is set to 1 than a random map will be chosen after a map finished.
 
 You can change maps by using these commands: ```skip_map```, ```sv_map mapname```, ```change_map mapname```<br/>
 ```skip_map``` will change the map to the next in the rotation.<br/>

--- a/README.md
+++ b/README.md
@@ -5,3 +5,29 @@ Slightly modified version of original [InfClass by necropotame](https://github.c
 ```bash
 sudo apt install libmaxminddb-dev
 ```
+## Maps
+You can create new maps with [TeeUniverse](https://github.com/teeuniverse/teeuniverse)
+
+### Map commands
+You can type these commands inside the rcon console (F2) or 
+you can also put them into a file called autoexec.cfg which should be next to your server binary.
+
+With ```sv_maprotation``` you can define what maps will be played in which order, for example:
+```sv_maprotation "infc_skull infc_warehouse infc_damascus"```
+With ```sv_rounds_per_map``` you can define how many rounds each map should be played before changing to the next map.
+
+You can change maps by using these commands: ```skip_map```, ```sv_map mapname```, ```change_map mapname```
+```skip_map``` will change the map to the next in the rotation.
+```sv_map infc_skull``` will instantly change map to a map called infc_skull.
+```change_map infc_skull``` will show the score of the current round and then change map.
+
+You can create map votes like this:
+```add_vote "infc_skull" change_map infc_skull```
+```add_vote "skip this map" skip_map```
+
+More commands:
+```inf_min_rounds_map_vote``` how many rounds should be played on a map before players can start a map vote.
+```inf_min_player_percent_map_vote``` how many percent of all players need to vote for a map in order to start a map vote.
+```inf_min_player_number_map_vote``` how many players need to vote for a map in order to start a map vote.
+If either ```inf_min_player_percent_map_vote``` or ```inf_min_player_number_map_vote``` becomes true, a map vote will start.
+By default these features are deactivated.

--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ sudo apt install libmaxminddb-dev
 You can create new maps with [TeeUniverse](https://github.com/teeuniverse/teeuniverse)
 
 ### Map commands
-You can type these commands inside the rcon console (F2) or 
+You can type these commands inside the rcon console (F2) or <br/>
 you can also put them into a file called autoexec.cfg which should be next to your server binary.
 
-With ```sv_maprotation``` you can define what maps will be played in which order, for example:
-```sv_maprotation "infc_skull infc_warehouse infc_damascus"```
+With ```sv_maprotation``` you can define what maps will be played in which order, for example:<br/>
+```sv_maprotation "infc_skull infc_warehouse infc_damascus"```<br/>
 With ```sv_rounds_per_map``` you can define how many rounds each map should be played before changing to the next map.
 
-You can change maps by using these commands: ```skip_map```, ```sv_map mapname```, ```change_map mapname```
-```skip_map``` will change the map to the next in the rotation.
-```sv_map infc_skull``` will instantly change map to a map called infc_skull.
+You can change maps by using these commands: ```skip_map```, ```sv_map mapname```, ```change_map mapname```<br/>
+```skip_map``` will change the map to the next in the rotation.<br/>
+```sv_map infc_skull``` will instantly change map to a map called infc_skull.<br/>
 ```change_map infc_skull``` will show the score of the current round and then change map.
 
-You can create map votes like this:
-```add_vote "infc_skull" change_map infc_skull```
-```add_vote "skip this map" skip_map```
+You can create map votes like this:<br/>
+```add_vote "infc_skull" change_map infc_skull```<br/>
+```add_vote "skip this map" skip_map```<br/>
 
-More commands:
-```inf_min_rounds_map_vote``` how many rounds should be played on a map before players can start a map vote.
-```inf_min_player_percent_map_vote``` how many percent of all players need to vote for a map in order to start a map vote.
-```inf_min_player_number_map_vote``` how many players need to vote for a map in order to start a map vote.
-If either ```inf_min_player_percent_map_vote``` or ```inf_min_player_number_map_vote``` becomes true, a map vote will start.
+More commands:<br/>
+```inf_min_rounds_map_vote``` how many rounds should be played on a map before players can start a map vote.<br/>
+```inf_min_player_percent_map_vote``` how many percent of all players need to vote for a map in order to start a map vote.<br/>
+```inf_min_player_number_map_vote``` how many players need to vote for a map in order to start a map vote.<br/>
+If either ```inf_min_player_percent_map_vote``` or ```inf_min_player_number_map_vote``` becomes true, a map vote will start.<br/>
 By default these features are deactivated.

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -339,7 +339,6 @@ public:
 	virtual void RemoveMapVotesForID(int ClientID) = 0;
 	virtual void ResetMapVotes() = 0;
 	virtual CMapVote* GetMapVote() = 0;
-	virtual void GetCurrentMapName(char* pMapName, int MapNameSize) = 0;
 	
 	virtual int GetTimeShiftUnit() const = 0; //In ms
 /* INFECTION MODIFICATION END *****************************************/

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -339,6 +339,7 @@ public:
 	virtual void RemoveMapVotesForID(int ClientID) = 0;
 	virtual void ResetMapVotes() = 0;
 	virtual CMapVote* GetMapVote() = 0;
+	virtual void GetCurrentMapName(char* pMapName, int MapNameSize) = 0;
 	
 	virtual int GetTimeShiftUnit() const = 0; //In ms
 /* INFECTION MODIFICATION END *****************************************/

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -339,6 +339,7 @@ public:
 	virtual void RemoveMapVotesForID(int ClientID) = 0;
 	virtual void ResetMapVotes() = 0;
 	virtual CMapVote* GetMapVote() = 0;
+	virtual int GetMinPlayersForMap(const char* pMapName) = 0;
 	
 	virtual int GetTimeShiftUnit() const = 0; //In ms
 /* INFECTION MODIFICATION END *****************************************/

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -73,6 +73,7 @@ enum
 enum
 {
 	MAX_ACCUSATIONS = 8,
+	MAX_MAPVOTEADDRESSES = 16,
 };
 
 enum
@@ -128,6 +129,15 @@ public:
 	{
 		int m_Num;
 		NETADDR m_Addresses[MAX_ACCUSATIONS];
+	};
+
+	struct CMapVote
+	{
+		const char *m_pCommand; // for example "change_map infc_warehouse" or "skip_map"
+		int m_Num; // how many people want to start this vote
+		NETADDR *m_pAddresses; // addresses of the people who want to start this vote
+		const char *m_pDesc; // name of the vote
+		const char *m_pReason;
 	};
 	
 	virtual ~IServer() {};
@@ -325,6 +335,10 @@ public:
 	virtual void AddAccusation(int From, int To, const char* pReason) = 0;
 	virtual bool ClientShouldBeBanned(int ClientID) = 0;
 	virtual void RemoveAccusations(int ClientID) = 0;
+	virtual void AddMapVote(int From, const char* pCommand, const char* pReason, const char* pDesc) = 0;
+	virtual void RemoveMapVotesForID(int ClientID) = 0;
+	virtual void ResetMapVotes() = 0;
+	virtual CMapVote* GetMapVote() = 0;
 	
 	virtual int GetTimeShiftUnit() const = 0; //In ms
 /* INFECTION MODIFICATION END *****************************************/
@@ -333,6 +347,8 @@ public:
 	virtual void SetCustClt(int ClientID) = 0;
 	// InfClassR spectators vector
 	std::vector<int> spectators_id;
+
+	virtual int GetActivePlayerCount() = 0;
 };
 
 class IGameServer : public IInterface

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1877,7 +1877,7 @@ int CServer::LoadMap(const char *pMapName)
 				isEndOfFile = true;
 				
 				//Load one line
-				int MapInfoLineLenth = 0;
+				int MapInfoLineLength = 0;
 				char c;
 				while(io_read(File, &c, 1))
 				{
@@ -1886,12 +1886,12 @@ int CServer::LoadMap(const char *pMapName)
 					if(c == '\n') break;
 					else
 					{
-						MapInfoLine[MapInfoLineLenth] = c;
-						MapInfoLineLenth++;
+						MapInfoLine[MapInfoLineLength] = c;
+						MapInfoLineLength++;
 					}
 				}
 				
-				MapInfoLine[MapInfoLineLenth] = 0;
+				MapInfoLine[MapInfoLineLength] = 0;
 				
 				//Get the key
 				if(str_comp_nocase_num(MapInfoLine, "timelimit ", 10) == 0)
@@ -1908,6 +1908,50 @@ int CServer::LoadMap(const char *pMapName)
 /* INFECTION MODIFICATION END *****************************************/
 	
 	return 1;
+}
+
+int CServer::GetMinPlayersForMap(const char* pMapName)
+{
+	int MinPlayers = 0;
+	char MapInfoFilename[256];
+	str_format(MapInfoFilename, sizeof(MapInfoFilename), "maps/%s.mapinfo", pMapName);
+	IOHANDLE File = Storage()->OpenFile(MapInfoFilename, IOFLAG_READ, IStorage::TYPE_ALL);
+
+	if(!File)
+		return 0;
+
+	char MapInfoLine[512];
+	bool isEndOfFile = false;
+	while(!isEndOfFile)
+	{
+		isEndOfFile = true;
+		
+		//Load one line
+		int MapInfoLineLength = 0;
+		char c;
+		while(io_read(File, &c, 1))
+		{
+			isEndOfFile = false;
+			
+			if(c == '\n') break;
+			else
+			{
+				MapInfoLine[MapInfoLineLength] = c;
+				MapInfoLineLength++;
+			}
+		}
+		
+		MapInfoLine[MapInfoLineLength] = 0;
+		
+		//Get the key
+		if(str_comp_nocase_num(MapInfoLine, "minplayers ", 11) == 0)
+		{
+			MinPlayers = str_toint(MapInfoLine+11);
+		}
+	}
+	io_close(File);
+
+	return MinPlayers;
 }
 
 void CServer::InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, IConsole *pConsole)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1754,12 +1754,6 @@ void CServer::PumpNetwork()
 	m_Econ.Update();
 }
 
-// copies current map name into pMapName
-void CServer::GetCurrentMapName(char* pMapName, int MapNameSize)
-{
-	str_copy(pMapName, m_aCurrentMap, MapNameSize);
-}
-
 char *CServer::GetMapName()
 {
 	// get the name of the map without his path

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1754,6 +1754,12 @@ void CServer::PumpNetwork()
 	m_Econ.Update();
 }
 
+// copies current map name into pMapName
+void CServer::GetCurrentMapName(char* pMapName, int MapNameSize)
+{
+	str_copy(pMapName, m_aCurrentMap, MapNameSize);
+}
+
 char *CServer::GetMapName()
 {
 	// get the name of the map without his path

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -7,6 +7,7 @@
 #include <engine/server/netsession.h>
 #include <engine/server/roundstatistics.h>
 #include <game/server/classes.h>
+#include <game/voting.h>
 
 /* DDNET MODIFICATION START *******************************************/
 #include "sql_connector.h"
@@ -372,6 +373,9 @@ private:
 	CRoundStatistics m_RoundStatistics;
 	CNetSession<IServer::CClientSession> m_NetSession;
 	CNetSession<IServer::CClientAccusation> m_NetAccusation;
+
+	IServer::CMapVote m_MapVotes[MAX_VOTE_OPTIONS];
+	int m_MapVotesCounter;
 	
 #ifdef CONF_SQL
 public:
@@ -401,6 +405,13 @@ public:
 	virtual void AddAccusation(int From, int To, const char* pReason);
 	virtual bool ClientShouldBeBanned(int ClientID);
 	virtual void RemoveAccusations(int ClientID);
+
+	virtual void AddMapVote(int From, const char* pCommand, const char* pReason, const char* pDesc);
+	virtual void RemoveMapVotesForID(int ClientID);
+	virtual void ResetMapVotes();
+	virtual IServer::CMapVote* GetMapVote();
+
+	virtual int GetActivePlayerCount();
 	
 	virtual int GetTimeShiftUnit() const { return m_TimeShiftUnit; } //In ms
 /* INFECTION MODIFICATION END *****************************************/

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -410,7 +410,6 @@ public:
 	virtual void RemoveMapVotesForID(int ClientID);
 	virtual void ResetMapVotes();
 	virtual IServer::CMapVote* GetMapVote();
-	virtual void GetCurrentMapName(char* pMapName, int MapNameSize);
 
 	virtual int GetActivePlayerCount();
 	

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -410,6 +410,7 @@ public:
 	virtual void RemoveMapVotesForID(int ClientID);
 	virtual void ResetMapVotes();
 	virtual IServer::CMapVote* GetMapVote();
+	virtual int GetMinPlayersForMap(const char* pMapName);
 
 	virtual int GetActivePlayerCount();
 	

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -410,6 +410,7 @@ public:
 	virtual void RemoveMapVotesForID(int ClientID);
 	virtual void ResetMapVotes();
 	virtual IServer::CMapVote* GetMapVote();
+	virtual void GetCurrentMapName(char* pMapName, int MapNameSize);
 
 	virtual int GetActivePlayerCount();
 	

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -56,8 +56,8 @@ MACRO_CONFIG_INT(InfLeaverBanTime, inf_leaver_ban_time, 5, 0, 180, CFGFLAG_SERVE
 MACRO_CONFIG_INT(InfFastDownload, inf_fast_download, 1, 0, 1, CFGFLAG_SERVER, "Enables fast download of maps")
 MACRO_CONFIG_INT(InfMapWindow, inf_map_window, 15, 0, 100, CFGFLAG_SERVER, "Map downloading send-ahead window")
 MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_for_map_vote, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
-MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_for_map_vote, 30, 0, 100, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
-MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_for_map_vote, 1, 1, 16, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")
+MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_for_map_vote, 30, 0, 200, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
+MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_for_map_vote, 1, 1, 32, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")
 MACRO_CONFIG_INT(InfConWaitingTime, inf_con_waiting_time, 1, 0, 60, CFGFLAG_SERVER, "Number of seconds to wait before enter the game")
 MACRO_CONFIG_INT(InfCaptcha, inf_captcha, 0, 0, 1, CFGFLAG_SERVER, "Enable captcha")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -56,9 +56,9 @@ MACRO_CONFIG_INT(InfLeaverBanTime, inf_leaver_ban_time, 5, 0, 180, CFGFLAG_SERVE
 MACRO_CONFIG_INT(InfFastDownload, inf_fast_download, 1, 0, 1, CFGFLAG_SERVER, "Enables fast download of maps")
 MACRO_CONFIG_INT(InfMapWindow, inf_map_window, 15, 0, 100, CFGFLAG_SERVER, "Map downloading send-ahead window")
 MACRO_CONFIG_INT(InfShowScoreTime, inf_show_score_time, 3, 0, 12, CFGFLAG_SERVER, "Number of seconds the score will be shown at the end of a round")
-MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_for_map_vote, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
-MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_for_map_vote, 30, 0, 200, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
-MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_for_map_vote, 1, 1, 32, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")
+MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_map_vote, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
+MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_map_vote, 30, 0, 200, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
+MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_map_vote, 1, 1, 32, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")
 MACRO_CONFIG_INT(InfConWaitingTime, inf_con_waiting_time, 1, 0, 60, CFGFLAG_SERVER, "Number of seconds to wait before enter the game")
 MACRO_CONFIG_INT(InfCaptcha, inf_captcha, 0, 0, 1, CFGFLAG_SERVER, "Enable captcha")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -56,6 +56,7 @@ MACRO_CONFIG_INT(InfLeaverBanTime, inf_leaver_ban_time, 5, 0, 180, CFGFLAG_SERVE
 MACRO_CONFIG_INT(InfFastDownload, inf_fast_download, 1, 0, 1, CFGFLAG_SERVER, "Enables fast download of maps")
 MACRO_CONFIG_INT(InfMapWindow, inf_map_window, 15, 0, 100, CFGFLAG_SERVER, "Map downloading send-ahead window")
 MACRO_CONFIG_INT(InfShowScoreTime, inf_show_score_time, 3, 0, 12, CFGFLAG_SERVER, "Number of seconds the score will be shown at the end of a round")
+MACRO_CONFIG_INT(InfMaprotationRandom, inf_maprotation_random, 0, 0, 1, CFGFLAG_SERVER, "When enabled, next map in rotation will be chosen randomly")
 MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_map_vote, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
 MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_map_vote, 30, 0, 200, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
 MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_map_vote, 1, 1, 32, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -55,6 +55,7 @@ MACRO_CONFIG_INT(InfAccusationThreshold, inf_accusation_threshold, 4, 0, 8, CFGF
 MACRO_CONFIG_INT(InfLeaverBanTime, inf_leaver_ban_time, 5, 0, 180, CFGFLAG_SERVER, "How long an infected gets banned (in minutes), when leaving and leaving causes a human to get infected")
 MACRO_CONFIG_INT(InfFastDownload, inf_fast_download, 1, 0, 1, CFGFLAG_SERVER, "Enables fast download of maps")
 MACRO_CONFIG_INT(InfMapWindow, inf_map_window, 15, 0, 100, CFGFLAG_SERVER, "Map downloading send-ahead window")
+MACRO_CONFIG_INT(InfShowScoreTime, inf_show_score_time, 3, 0, 12, CFGFLAG_SERVER, "Number of seconds the score will be shown at the end of a round")
 MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_for_map_vote, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
 MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_for_map_vote, 30, 0, 200, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
 MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_for_map_vote, 1, 1, 32, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -56,8 +56,11 @@ MACRO_CONFIG_INT(InfLeaverBanTime, inf_leaver_ban_time, 5, 0, 180, CFGFLAG_SERVE
 MACRO_CONFIG_INT(InfFastDownload, inf_fast_download, 1, 0, 1, CFGFLAG_SERVER, "Enables fast download of maps")
 MACRO_CONFIG_INT(InfMapWindow, inf_map_window, 15, 0, 100, CFGFLAG_SERVER, "Map downloading send-ahead window")
 MACRO_CONFIG_INT(InfMinRoundsForMapVote, inf_min_rounds_for_map_vote, 0, 0, 100, CFGFLAG_SERVER, "Minimum number of rounds before a new map can be voted")
+MACRO_CONFIG_INT(InfMinPlayerPercentForMapVote, inf_min_player_percent_for_map_vote, 30, 0, 100, CFGFLAG_SERVER, "Minimum percentage of players that are needed to start a map vote")
+MACRO_CONFIG_INT(InfMinPlayerNumberForMapVote, inf_min_player_number_for_map_vote, 1, 1, 16, CFGFLAG_SERVER, "Minimum number of players that are needed to start a map vote")
 MACRO_CONFIG_INT(InfConWaitingTime, inf_con_waiting_time, 1, 0, 60, CFGFLAG_SERVER, "Number of seconds to wait before enter the game")
 MACRO_CONFIG_INT(InfCaptcha, inf_captcha, 0, 0, 1, CFGFLAG_SERVER, "Enable captcha")
+
 MACRO_CONFIG_INT(InfDefenderLimit, inf_defender_limit, 40, 0, 64, CFGFLAG_SERVER, "Maximum number of defenders in game")
 MACRO_CONFIG_INT(InfMedicLimit, inf_medic_limit, 20, 0, 64, CFGFLAG_SERVER, "Maximum number of medics in game")
 MACRO_CONFIG_INT(InfHeroLimit, inf_hero_limit, 10, 0, 64, CFGFLAG_SERVER, "Maximum number of heros in game")

--- a/src/game/server/entities/hero-flag.cpp
+++ b/src/game/server/entities/hero-flag.cpp
@@ -35,13 +35,30 @@ void CHeroFlag::FindPosition()
 	m_Pos = GameServer()->m_pController->HeroFlagPositions()[Index];
 }
 
+void CHeroFlag::SetCoolDown()
+{
+	// Set cooldown for next flag depending on how many players are online
+	int PlayerCount = Server()->GetActivePlayerCount();
+	if (PlayerCount <= 1)
+	{
+		// only 1 player on, let him find as many flags as he wants
+		m_CoolDownTick = 2;
+		return;
+	}
+	float t = (8-PlayerCount) / 8.0f;
+	if (t < 0.0f) 
+		t = 0.0f;
+	m_CoolDownTick = Server()->TickSpeed() * (15+(120*t));
+}
+
 void CHeroFlag::GiveGift(CCharacter* pHero)
 {
 	// Find other players	
 	GameServer()->SendBroadcast_Localization(-1, BROADCAST_PRIORITY_GAMEANNOUNCE, BROADCAST_DURATION_GAMEANNOUNCE, _("The Hero found the flag!"), NULL);
 	GameServer()->CreateSoundGlobal(SOUND_CTF_CAPTURE);
-	m_CoolDownTick = Server()->TickSpeed()*15;
-	
+
+	SetCoolDown();
+
 	for(CCharacter *p = (CCharacter*) GameWorld()->FindFirst(CGameWorld::ENTTYPE_CHARACTER); p; p = (CCharacter *)p->TypeNext())
 	{
 		if(p->IsInfected())

--- a/src/game/server/entities/hero-flag.h
+++ b/src/game/server/entities/hero-flag.h
@@ -24,6 +24,9 @@ public:
 	virtual void FindPosition();
 	virtual void Snap(int SnappingClient);
 	void GiveGift(CCharacter* pHero);
+
+private:
+	void SetCoolDown();
 };
 
 #endif

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1515,10 +1515,8 @@ void CGameContext::OnCallVote(void *pRawMsg, int ClientID)
 						if (MapVoteType == SV_MAP || MapVoteType == CHANGE_MAP)
 						{
 							char MapName[VOTE_CMD_LENGTH] = {0};
-							char CurrentMapName[VOTE_CMD_LENGTH] = {0};
-							Server()->GetCurrentMapName(CurrentMapName, VOTE_CMD_LENGTH);
 							GetMapNameFromCommand(MapName, pOption->m_aCommand);
-							if (str_comp_nocase(MapName, CurrentMapName) == 0)
+							if (str_comp_nocase(MapName, g_Config.m_SvMap) == 0)
 							{
 								char aBufVoteMap[128];
 								str_format(aBufVoteMap, sizeof(aBufVoteMap), "Server is already on map %s", MapName);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -980,6 +980,19 @@ void CGameContext::OnTick()
 			}
 		}
 	}
+
+	//Check for mapVote
+	if(!m_VoteCloseTime && m_pController->CanVote()) // there is currently no vote && its the start of a round
+	{
+		IServer::CMapVote* mapVote = Server()->GetMapVote();
+		if (mapVote)
+		{
+			char aChatmsg[512] = {0};
+			str_format(aChatmsg, sizeof(aChatmsg), "Starting vote '%s'", mapVote->m_pDesc);
+			SendChat(-1, CGameContext::CHAT_ALL, aChatmsg);
+			StartVote(mapVote->m_pDesc, mapVote->m_pCommand, mapVote->m_pReason);
+		}
+	}
 	
 	// check tuning
 	CheckPureTuning();
@@ -1231,6 +1244,8 @@ void CGameContext::OnTick()
 				Server()->SetRconCID(IServer::RCON_CID_SERV);
 				EndVote();
 				SendChat(-1, CGameContext::CHAT_ALL, "Vote passed");
+				if (IsMapVote(m_aVoteCommand) > 0) 
+					Server()->ResetMapVotes();
 
 				if(m_apPlayers[m_VoteCreator])
 					m_apPlayers[m_VoteCreator]->m_LastVoteCall = 0;
@@ -1239,6 +1254,8 @@ void CGameContext::OnTick()
 			{
 				EndVote();
 				SendChat(-1, CGameContext::CHAT_ALL, "Vote failed");
+				if (IsMapVote(m_aVoteCommand) > 0) 
+					Server()->ResetMapVotes();
 				
 				//Remove accusation if needed
 				if(m_VoteBanClientID >= 0)
@@ -1380,6 +1397,176 @@ void CGameContext::OnClientDrop(int ClientID, int Type, const char *pReason)
 	// InfClassR end
 }
 
+int CGameContext::IsMapVote(const char *pVoteCommand)
+{
+	char command[512] = {0};
+	int i = 0;
+	for ( ; i < 510; i++)
+	{
+		if (pVoteCommand[i] == 0) break;
+		if (pVoteCommand[i] == ' ') break;
+		command[i] = pVoteCommand[i];
+	}
+	command[++i] = 0;
+	if(str_comp_nocase(command, "sv_map") == 0) return 1;
+	if(str_comp_nocase(command, "change_map") == 0) return 2;
+	if(str_comp_nocase(command, "skip_map") == 0) return 3;
+	return 0;
+}
+
+// will be called when a player wants to start a vote
+void CGameContext::OnCallVote(void *pRawMsg, int ClientID)
+{
+	CPlayer *pPlayer = m_apPlayers[ClientID];
+
+	if(g_Config.m_SvSpamprotection && pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry+Server()->TickSpeed()*3 > Server()->Tick())
+		return;
+				
+	int64 Now = Server()->Tick();
+	pPlayer->m_LastVoteTry = Now;
+			
+	CNetMsg_Cl_CallVote *pMsg = (CNetMsg_Cl_CallVote *)pRawMsg;
+	const char *pReason = pMsg->m_Reason[0] ? pMsg->m_Reason : "No reason given";
+
+	if(str_comp_nocase(pMsg->m_Type, "kick") == 0)
+	{
+		int KickID = str_toint(pMsg->m_Value);
+		if(KickID < 0 || KickID >= MAX_CLIENTS || !m_apPlayers[KickID])
+		{
+			SendChatTarget(ClientID, "Invalid client id to kick");
+			return;
+		}
+		if(KickID == ClientID)
+		{
+			SendChatTarget(ClientID, "You can't kick yourself");
+			return;
+		}
+		if(Server()->IsAuthed(KickID))
+		{
+			SendChatTarget(ClientID, "You can't kick admins");
+			char aBufKick[128];
+			str_format(aBufKick, sizeof(aBufKick), "'%s' called for vote to kick you", Server()->ClientName(ClientID));
+			SendChatTarget(KickID, aBufKick);
+			return;
+		}
+
+		Server()->AddAccusation(ClientID, KickID, pReason);
+	}
+	else
+	{
+		if(pPlayer->GetTeam() == TEAM_SPECTATORS)
+		{
+			SendChatTarget(ClientID, "Spectators aren't allowed to start a vote.");
+			return;
+		}
+
+		if(m_VoteCloseTime)
+		{
+			SendChatTarget(ClientID, "Wait for current vote to end before calling a new one.");
+			return;
+		}
+
+		int Timeleft = pPlayer->m_LastVoteCall + Server()->TickSpeed()*60 - Now;
+		if(pPlayer->m_LastVoteCall && Timeleft > 0)
+		{
+			char aChatmsg[512] = {0};
+			str_format(aChatmsg, sizeof(aChatmsg), "You must wait %d seconds before making another vote", (Timeleft/Server()->TickSpeed())+1);
+			SendChatTarget(ClientID, aChatmsg);
+			return;
+		}
+
+		char aChatmsg[512] = {0};
+		char aDesc[VOTE_DESC_LENGTH] = {0};
+		char aCmd[VOTE_CMD_LENGTH] = {0};
+
+		if(str_comp_nocase(pMsg->m_Type, "option") == 0)
+		{
+
+			CVoteOptionServer *pOption = m_pVoteOptionFirst;
+			while(pOption)
+			{
+				if(str_comp_nocase(pMsg->m_Value, pOption->m_aDescription) == 0)
+				{
+					int MapVoteType = IsMapVote(pOption->m_aCommand);
+					if (MapVoteType > 0) // this is a map vote
+					{
+						int RoundCount = m_pController->GetRoundCount();
+						if (m_pController->IsRoundEndTime())
+							RoundCount++;
+						if (g_Config.m_InfMinRoundsForMapVote > RoundCount && Server()->GetActivePlayerCount() > 1)
+						{
+							char aBufVoteMap[128];
+							str_format(aBufVoteMap, sizeof(aBufVoteMap), "Each map must be played at least %i rounds before calling a map vote", g_Config.m_InfMinRoundsForMapVote);
+							SendChatTarget(ClientID, aBufVoteMap);
+							return;
+						}
+					}
+					if (g_Config.m_InfMinPlayerNumberForMapVote <= 1 || MapVoteType == 0) 
+					{
+						if(!m_pController->CanVote())
+						{
+							SendChatTarget(ClientID, "Votes are only allowed when the round start.");
+							return;
+						}
+
+						str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)", Server()->ClientName(ClientID),
+								pOption->m_aDescription, pReason);
+						str_format(aDesc, sizeof(aDesc), "%s", pOption->m_aDescription);
+						str_format(aCmd, sizeof(aCmd), "%s", pOption->m_aCommand);
+						break;
+					}
+					// the vote is a map vote
+					Server()->AddMapVote(ClientID, pOption->m_aCommand, pReason, pOption->m_aDescription);
+					return;
+				}
+
+				pOption = pOption->m_pNext;
+			}
+
+			if(!pOption)
+			{
+				str_format(aChatmsg, sizeof(aChatmsg), "'%s' isn't an option on this server", pMsg->m_Value);
+				SendChatTarget(ClientID, aChatmsg);
+				return;
+			}
+		}
+		else if(str_comp_nocase(pMsg->m_Type, "spectate") == 0)
+		{
+			if(!g_Config.m_SvVoteSpectate)
+			{
+				SendChatTarget(ClientID, "Server does not allow voting to move players to spectators");
+				return;
+			}
+
+			int SpectateID = str_toint(pMsg->m_Value);
+			if(SpectateID < 0 || SpectateID >= MAX_CLIENTS || !m_apPlayers[SpectateID] || m_apPlayers[SpectateID]->GetTeam() == TEAM_SPECTATORS)
+			{
+				SendChatTarget(ClientID, "Invalid client id to move");
+				return;
+			}
+			if(SpectateID == ClientID)
+			{
+				SendChatTarget(ClientID, "You can't move yourself");
+				return;
+			}
+
+			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to move '%s' to spectators (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), pReason);
+			str_format(aDesc, sizeof(aDesc), "move '%s' to spectators", Server()->ClientName(SpectateID));
+			str_format(aCmd, sizeof(aCmd), "set_team %d -1 %d", SpectateID, g_Config.m_SvVoteSpectateRejoindelay);
+		}
+
+		if(aCmd[0])
+		{
+			SendChat(-1, CGameContext::CHAT_ALL, aChatmsg);
+			StartVote(aDesc, aCmd, pReason);
+			pPlayer->m_Vote = 1;
+			pPlayer->m_VotePos = m_VotePos = 1;
+			m_VoteCreator = ClientID;
+			pPlayer->m_LastVoteCall = Now;
+		}
+	}
+}
+
 void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 {
 	void *pRawMsg = m_NetObjHandler.SecureUnpackMsg(MsgID, pUnpacker);
@@ -1505,139 +1692,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		}
 		else if(MsgID == NETMSGTYPE_CL_CALLVOTE)
 		{
-			if(g_Config.m_SvSpamprotection && pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry+Server()->TickSpeed()*3 > Server()->Tick())
-				return;
-				
-			int64 Now = Server()->Tick();
-			pPlayer->m_LastVoteTry = Now;
-			
-			CNetMsg_Cl_CallVote *pMsg = (CNetMsg_Cl_CallVote *)pRawMsg;
-			const char *pReason = pMsg->m_Reason[0] ? pMsg->m_Reason : "No reason given";
-			
-			if(str_comp_nocase(pMsg->m_Type, "kick") == 0)
-			{
-				int KickID = str_toint(pMsg->m_Value);
-				if(KickID < 0 || KickID >= MAX_CLIENTS || !m_apPlayers[KickID])
-				{
-					SendChatTarget(ClientID, "Invalid client id to kick");
-					return;
-				}
-				if(KickID == ClientID)
-				{
-					SendChatTarget(ClientID, "You can't kick yourself");
-					return;
-				}
-				if(Server()->IsAuthed(KickID))
-				{
-					SendChatTarget(ClientID, "You can't kick admins");
-					char aBufKick[128];
-					str_format(aBufKick, sizeof(aBufKick), "'%s' called for vote to kick you", Server()->ClientName(ClientID));
-					SendChatTarget(KickID, aBufKick);
-					return;
-				}
-
-				Server()->AddAccusation(ClientID, KickID, pReason);
-			}
-			else
-			{
-				if(pPlayer->GetTeam() == TEAM_SPECTATORS)
-				{
-					SendChatTarget(ClientID, "Spectators aren't allowed to start a vote.");
-					return;
-				}
-
-				if(m_VoteCloseTime)
-				{
-					SendChatTarget(ClientID, "Wait for current vote to end before calling a new one.");
-					return;
-				}
-
-				if (g_Config.m_InfMinRoundsForMapVote > m_pController->GetRoundCount())
-				{
-					char aBufVoteMap[128];
-					str_format(aBufVoteMap, sizeof(aBufVoteMap), "Each map must be played at least %i rounds before calling a map vote", g_Config.m_InfMinRoundsForMapVote);
-					SendChatTarget(ClientID, aBufVoteMap);
-					return;
-				}
-
-				if(!m_pController->CanVote())
-				{
-					SendChatTarget(ClientID, "Votes are only allowed when the round start.");
-					return;
-				}
-
-				int Timeleft = pPlayer->m_LastVoteCall + Server()->TickSpeed()*60 - Now;
-				if(pPlayer->m_LastVoteCall && Timeleft > 0)
-				{
-					char aChatmsg[512] = {0};
-					str_format(aChatmsg, sizeof(aChatmsg), "You must wait %d seconds before making another vote", (Timeleft/Server()->TickSpeed())+1);
-					SendChatTarget(ClientID, aChatmsg);
-					return;
-				}
-
-				char aChatmsg[512] = {0};
-				char aDesc[VOTE_DESC_LENGTH] = {0};
-				char aCmd[VOTE_CMD_LENGTH] = {0};
-
-				if(str_comp_nocase(pMsg->m_Type, "option") == 0)
-				{
-					CVoteOptionServer *pOption = m_pVoteOptionFirst;
-					while(pOption)
-					{
-						if(str_comp_nocase(pMsg->m_Value, pOption->m_aDescription) == 0)
-						{
-							str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)", Server()->ClientName(ClientID),
-										pOption->m_aDescription, pReason);
-							str_format(aDesc, sizeof(aDesc), "%s", pOption->m_aDescription);
-							str_format(aCmd, sizeof(aCmd), "%s", pOption->m_aCommand);
-							break;
-						}
-
-						pOption = pOption->m_pNext;
-					}
-
-					if(!pOption)
-					{
-						str_format(aChatmsg, sizeof(aChatmsg), "'%s' isn't an option on this server", pMsg->m_Value);
-						SendChatTarget(ClientID, aChatmsg);
-						return;
-					}
-				}
-				else if(str_comp_nocase(pMsg->m_Type, "spectate") == 0)
-				{
-					if(!g_Config.m_SvVoteSpectate)
-					{
-						SendChatTarget(ClientID, "Server does not allow voting to move players to spectators");
-						return;
-					}
-
-					int SpectateID = str_toint(pMsg->m_Value);
-					if(SpectateID < 0 || SpectateID >= MAX_CLIENTS || !m_apPlayers[SpectateID] || m_apPlayers[SpectateID]->GetTeam() == TEAM_SPECTATORS)
-					{
-						SendChatTarget(ClientID, "Invalid client id to move");
-						return;
-					}
-					if(SpectateID == ClientID)
-					{
-						SendChatTarget(ClientID, "You can't move yourself");
-						return;
-					}
-
-					str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to move '%s' to spectators (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), pReason);
-					str_format(aDesc, sizeof(aDesc), "move '%s' to spectators", Server()->ClientName(SpectateID));
-					str_format(aCmd, sizeof(aCmd), "set_team %d -1 %d", SpectateID, g_Config.m_SvVoteSpectateRejoindelay);
-				}
-
-				if(aCmd[0])
-				{
-					SendChat(-1, CGameContext::CHAT_ALL, aChatmsg);
-					StartVote(aDesc, aCmd, pReason);
-					pPlayer->m_Vote = 1;
-					pPlayer->m_VotePos = m_VotePos = 1;
-					m_VoteCreator = ClientID;
-					pPlayer->m_LastVoteCall = Now;
-				}
-			}
+			OnCallVote(pRawMsg, ClientID);
 		}
 		else if(MsgID == NETMSGTYPE_CL_VOTE)
 		{
@@ -4238,11 +4293,12 @@ void CGameContext::List(int ClientID, const char* filter)
 	SendChatTarget(ClientID, buf);
 }
 
-void CGameContext::AddSpectatorCID(int ClientID) {
+void CGameContext::AddSpectatorCID(int ClientID)
+{
+	Server()->RemoveMapVotesForID(ClientID);
 	auto& vec = Server()->spectators_id;
-	if(!(std::find(vec.begin(), vec.end(), ClientID) != vec.end())) {
+	if(!(std::find(vec.begin(), vec.end(), ClientID) != vec.end()))
 		vec.push_back(ClientID);
-	}
 }
 
 void CGameContext::RemoveSpectatorCID(int ClientID) {

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1440,6 +1440,8 @@ void CGameContext::GetMapNameFromCommand(char* pMapName, const char *pCommand)
 void CGameContext::OnCallVote(void *pRawMsg, int ClientID)
 {
 	CPlayer *pPlayer = m_apPlayers[ClientID];
+	if (!pPlayer)
+		return;
 
 	if(g_Config.m_SvSpamprotection && pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry+Server()->TickSpeed()*3 > Server()->Tick())
 		return;
@@ -1503,17 +1505,19 @@ void CGameContext::OnCallVote(void *pRawMsg, int ClientID)
 
 		if(str_comp_nocase(pMsg->m_Type, "option") == 0)
 		{
+			// this vote is not a kick/ban or spectate vote
 
 			CVoteOptionServer *pOption = m_pVoteOptionFirst;
-			while(pOption)
+			while(pOption) // loop through all option votes to find out which vote it is
 			{
-				if(str_comp_nocase(pMsg->m_Value, pOption->m_aDescription) == 0)
+				if(str_comp_nocase(pMsg->m_Value, pOption->m_aDescription) == 0) // found out which vote it is
 				{
 					int MapVoteType = IsMapVote(pOption->m_aCommand);
 					if (MapVoteType > 0) // this is a map vote
 					{
 						if (MapVoteType == SV_MAP || MapVoteType == CHANGE_MAP)
 						{
+							// check if we are already playing on the map the user wants to vote
 							char MapName[VOTE_CMD_LENGTH] = {0};
 							GetMapNameFromCommand(MapName, pOption->m_aCommand);
 							if (str_comp_nocase(MapName, g_Config.m_SvMap) == 0)
@@ -1538,19 +1542,21 @@ void CGameContext::OnCallVote(void *pRawMsg, int ClientID)
 					}
 					if (g_Config.m_InfMinPlayerNumberForMapVote <= 1 || MapVoteType == 0) 
 					{
+						// (this is not a map vote) or ("InfMinPlayerNumberForMapVote <= 1" and we keep default behaviour)
 						if(!m_pController->CanVote())
 						{
 							SendChatTarget(ClientID, "Votes are only allowed when the round start.");
 							return;
 						}
-
+						
+						// copy information to start a vote 
 						str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)", Server()->ClientName(ClientID),
 								pOption->m_aDescription, pReason);
 						str_format(aDesc, sizeof(aDesc), "%s", pOption->m_aDescription);
 						str_format(aCmd, sizeof(aCmd), "%s", pOption->m_aCommand);
 						break;
 					}
-					// the vote is a map vote
+					// this vote is a map vote
 					Server()->AddMapVote(ClientID, pOption->m_aCommand, pReason, pOption->m_aDescription);
 					return;
 				}
@@ -1590,6 +1596,7 @@ void CGameContext::OnCallVote(void *pRawMsg, int ClientID)
 			str_format(aCmd, sizeof(aCmd), "set_team %d -1 %d", SpectateID, g_Config.m_SvVoteSpectateRejoindelay);
 		}
 
+		// Start a vote
 		if(aCmd[0])
 		{
 			SendChat(-1, CGameContext::CHAT_ALL, aChatmsg);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -253,6 +253,8 @@ private:
 	static bool ConCmdList(IConsole::IResult *pResult, void *pUserData);
 	static bool ConWitch(IConsole::IResult *pResult, void *pUserData);
 	bool PrivateMessage(const char* pStr, int ClientID, bool TeamChat);
+	void OnCallVote(void *pRawMsg, int ClientID);
+	int IsMapVote(const char *pVoteCommand);
 	
 public:
 	virtual void OnSetAuthed(int ClientID,int Level);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -253,8 +253,17 @@ private:
 	static bool ConCmdList(IConsole::IResult *pResult, void *pUserData);
 	static bool ConWitch(IConsole::IResult *pResult, void *pUserData);
 	bool PrivateMessage(const char* pStr, int ClientID, bool TeamChat);
+
 	void OnCallVote(void *pRawMsg, int ClientID);
 	int IsMapVote(const char *pVoteCommand);
+	void GetMapNameFromCommand(char* pMapName, const char *pCommand);
+
+	enum
+	{
+		SV_MAP = 1,
+		CHANGE_MAP = 2,
+		SKIP_MAP = 3
+	};
 	
 public:
 	virtual void OnSetAuthed(int ClientID,int Level);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -364,7 +364,7 @@ void IGameController::Tick()
 	if(m_GameOverTick != -1)
 	{
 		// game over.. wait for restart
-		if(Server()->Tick() > m_GameOverTick+Server()->TickSpeed()*12)
+		if(Server()->Tick() > m_GameOverTick+Server()->TickSpeed()*g_Config.m_InfShowScoreTime)
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -381,13 +381,9 @@ void IGameController::Tick()
 		else
 		{
 			int ScoreMode = PLAYERSCOREMODE_SCORE;
-			if((Server()->Tick() - m_GameOverTick) > Server()->TickSpeed() * 8)
+			if((Server()->Tick() - m_GameOverTick) > Server()->TickSpeed() * (g_Config.m_InfShowScoreTime/2.0f))
 			{
 				ScoreMode = PLAYERSCOREMODE_TIME;
-			}
-			else if((Server()->Tick() - m_GameOverTick) > Server()->TickSpeed() * 4)
-			{
-				ScoreMode = PLAYERSCOREMODE_SCORE;
 			}
 			
 			for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -127,6 +127,11 @@ int IGameController::GetRoundCount() {
 	return m_RoundCount;
 }
 
+bool IGameController::IsRoundEndTime() 
+{
+	return m_GameOverTick > 0;
+}
+
 void IGameController::StartRound()
 {
 	ResetGame();

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -85,6 +85,16 @@ public:
 
 	bool IsForceBalanced();
 
+	struct CMapRotationInfo
+	{
+		static const int MAX_MAPS = 256;
+		int m_MapNameIndices[MAX_MAPS]; // saves Indices where mapNames start inside of g_Config.m_SvMaprotation
+		int m_MapCount; // how many maps are in rotation
+		int m_CurrentMapNumber; // at what place the current map is, from 0 to (m_MapCount-1)
+	};
+	void GetMapRotationInfo(CMapRotationInfo *pMapRotationInfo);
+	void GetWordFromList(char *pNextWord, const char *pList, int ListIndex);
+
 	/*
 
 	*/

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -79,6 +79,7 @@ public:
 	virtual void EndRound();
 	void ChangeMap(const char *pToMap);
 	int GetRoundCount();
+	bool IsRoundEndTime();
 
 	bool IsFriendlyFire(int ClientID1, int ClientID2);
 


### PR DESCRIPTION
~~*** **PLeAsE dO NOT mErGE** ***~~ (ready to merge now)

This branch currently should not change the default behaviour of the server.

It gives server owners 2 more config vars:
inf_min_player_number_map_vote
inf_min_player_percent_map_vote

This feature is similar to the way votebans work currently.

If a player wants to start a map vote and inf_min_player_number_map_vote is 2. Than it needs 2 Players to start a map vote. A chat message will appear "PlayerX wants to start the vote blabla". If now a second player votes for the same map vote, the vote will start. 

inf_min_player_percent_map_vote will take a look on how many players are online and decide if a vote should be started. If either inf_min_player_number_map_vote or inf_min_player_percent_for_map_vote comes true a vote will start.

Votes will only start during the end of a round or during the start of a round.