### PR TITLE
Ignore picking random and show randomy selected class instead

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2188,9 +2188,8 @@ void CCharacter::Tick()
 					m_pPlayer->SetClass(NewClass);
 					m_pPlayer->SetOldClass(NewClass);
 					
-					// class '99' counts as picking "Random"
 					char aBuf[256];
-					str_format(aBuf, sizeof(aBuf), "choose_class player='%s' class='%d'", Server()->ClientName(m_pPlayer->GetCID()), Bonus ? 99 : NewClass);
+					str_format(aBuf, sizeof(aBuf), "choose_class player='%s' class='%d'", Server()->ClientName(m_pPlayer->GetCID()), NewClass);
 					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
 					
 					if(Bonus)


### PR DESCRIPTION
Stats will drop tracking random picks and instead will just count towards the randomly selected class that has been chosen