### PR TITLE
hero must stay still to show indicator + indicator made more visible

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -119,7 +119,8 @@ MACRO_CONFIG_INT(InfEnableNinja, inf_enable_ninja, 1, 0, 1, CFGFLAG_SERVER, "Mak
 MACRO_CONFIG_INT(InfEnableMedic, inf_enable_medic, 1, 0, 1, CFGFLAG_SERVER, "Makes the medic class available")
 MACRO_CONFIG_INT(InfEnableHero, inf_enable_hero, 1, 0, 1, CFGFLAG_SERVER, "Makes the hero class available")
 
-MACRO_CONFIG_INT(InfHeroFlagIndicator, inf_hero_flag_indicator, 0, 0, 1, CFGFLAG_SERVER, "Shows the heros in which direction the next flag is")
+MACRO_CONFIG_INT(InfHeroFlagIndicator, inf_hero_flag_indicator, 1, 0, 1, CFGFLAG_SERVER, "Shows the heros in which direction the next flag is")
+MACRO_CONFIG_INT(InfHeroFlagIndicatorTime, inf_hero_flag_indicator_time, 3, 0, 1000, CFGFLAG_SERVER, "How many seconds the hero has to stand still until the indicator is shown")
 
 MACRO_CONFIG_STR(FunRoundTitle, funround_title, 64, "Fun round", CFGFLAG_SERVER, "Fun round title")
 MACRO_CONFIG_INT(FunRoundLimit, funround_limit, 1, 0, 100, CFGFLAG_SERVER, "Number of possible fun rounds per map")

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -3161,7 +3161,7 @@ void CCharacter::Snap(int SnappingClient)
 		{
 			CHeroFlag *pFlag = m_pHeroFlag;
 
-			long tickLimit = m_pPlayer->m_LastActionTick+g_Config.m_InfHeroFlagIndicatorTime*Server()->TickSpeed();
+			long tickLimit = m_pPlayer->m_LastActionMoveTick+g_Config.m_InfHeroFlagIndicatorTime*Server()->TickSpeed();
 			
 			// Guide hero to flag
 			if(pFlag->GetCoolDown() <= 0 && Server()->Tick() > tickLimit)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3580,6 +3580,8 @@ bool CGameContext::ConHelp(IConsole::IResult *pResult, void *pUserData)
 			Buffer.append("\n\n");
 			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("The gift to all humans is only applied when the flag is surrounded by hearts and armor. This gift cooldown is shared between all heros."), NULL);
 			Buffer.append("\n\n");
+			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("Cannot find a flag? Stand still for some seconds, maybe you will get enlightened."), NULL);
+			Buffer.append("\n\n");
 			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("The hero cannot be healed by a medic, but he can withstand a thrust by an infected, an his health suffice."), NULL);
 			
 			pSelf->SendMOTD(ClientID, Buffer.buffer());

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -23,6 +23,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, int Team)
 	m_Team = GameServer()->m_pController->ClampTeam(Team);
 	m_SpectatorID = SPEC_FREEVIEW;
 	m_LastActionTick = Server()->Tick();
+	m_LastActionMoveTick = Server()->Tick();
 	m_TeamChangeTick = Server()->Tick();
 	
 /* INFECTION MODIFICATION START ***************************************/
@@ -133,6 +134,7 @@ void CPlayer::Tick()
 		++m_DieTick;
 		++m_ScoreStartTick;
 		++m_LastActionTick;
+		++m_LastActionMoveTick;
 		++m_TeamChangeTick;
  	}
 
@@ -489,6 +491,8 @@ void CPlayer::OnDirectInput(CNetObj_PlayerInput *NewInput)
 		m_LatestActivity.m_TargetX = NewInput->m_TargetX;
 		m_LatestActivity.m_TargetY = NewInput->m_TargetY;
 		m_LastActionTick = Server()->Tick();
+		if (NewInput->m_Direction || NewInput->m_Jump || NewInput->m_Hook)
+			m_LastActionMoveTick = Server()->Tick();
 	}
 }
 
@@ -541,6 +545,7 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 
 	m_Team = Team;
 	m_LastActionTick = Server()->Tick();
+	m_LastActionMoveTick = Server()->Tick();
 	m_SpectatorID = SPEC_FREEVIEW;
 	// we got to wait 0.5 secs before respawning
 	m_RespawnTick = Server()->Tick()+Server()->TickSpeed()/2;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -88,6 +88,7 @@ public:
 	int m_ScoreStartTick;
 	bool m_ForceBalanced;
 	int m_LastActionTick;
+	int m_LastActionMoveTick;
 	bool m_StolenSkin;
 	int m_TeamChangeTick;
 	struct


### PR DESCRIPTION
This enables you to set a time the hero must stay still until he can see the flag indicator.
If you set the time to 0 the flag indicator will always be shown.
The bullet was hard to see and you couldnt see it behind walls. This is why i changed it to a laser dot and also added a laser line that will appear for half a second indicating to you where the flag is.
#95 