### PR TITLE
If there are 3 players, 2 should become zombies

### DIFF
--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -133,7 +133,7 @@ void CGameControllerMOD::GetPlayerCounter(int ClientException, int& NumHumans, i
 	
 	if(NumHumans + NumInfected <= 1)
 		NumFirstInfected = 0;
-	else if(NumHumans + NumInfected <= 3)
+	else if(NumHumans + NumInfected <= 2)
 		NumFirstInfected = 1;
 	else
 		NumFirstInfected = 2;


### PR DESCRIPTION
Right now if there are 3 players, only 1 player will be infected at the start of the round.
This change will make it so 2 players will be infected.
I talked about this with other players online. 
It can be very unfair to the one zombie, for example one zombie might have to fight 2 engineers or scientists. If there is 1 v 1 it can also be very unfair, 1 scientist could put 2 mines in front of an exit and make it impossible for the zombie to reach him. This change will not make it perfect, but i think it is an improvement of the current situation. #48 