### PR TITLE
reduce max scientist mines to 1 if not enough players are online

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -834,6 +834,8 @@ void CCharacter::FireWeapon()
 				{
 					if(pIntersectMine) //Move the mine
 						GameServer()->m_World.DestroyEntity(pIntersectMine);
+					else if(Server()->GetActivePlayerCount() <= 2 && pOlderMine) // to few players, only allow 1 mine
+						GameServer()->m_World.DestroyEntity(pOlderMine);
 					else if(NbMine >= g_Config.m_InfMineLimit && pOlderMine)
 						GameServer()->m_World.DestroyEntity(pOlderMine);
 					


### PR DESCRIPTION
Only allow one scientist mine per scientist until there are atleast 3 players on.
1 v 1 a scientist can block himself with 2 mines and make it impossible to kill him.
#48