### PR TITLE
config var improvements

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -32,6 +32,7 @@
 
 #include "register.h"
 #include "server.h"
+#include <engine/shared/cfgvar_buffer.h>
 
 #include <cstring>
 /* INFECTION MODIFICATION START ***************************************/
@@ -2849,6 +2850,8 @@ int main(int argc, const char **argv) // ignore_convention
 
 	// restore empty config strings to their defaults
 	pConfig->RestoreStrings();
+
+	CCfgVarBuffer::Init();
 
 	pEngine->InitLogfile();
 

--- a/src/engine/shared/cfgvar_buffer.cpp
+++ b/src/engine/shared/cfgvar_buffer.cpp
@@ -1,0 +1,153 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+/* Modifications Copyright 2019 The InfclassR (https://github.com/yavl/teeworlds-infclassR/) Authors */
+
+#include <base/system.h>
+#include "cfgvar_buffer.h"
+#include "config.h"
+#include "console.h"
+#include <iostream>
+
+int CCfgVarBuffer::m_CfgVarsCounter;
+CCfgVarBuffer::CfgVar *CCfgVarBuffer::m_CfgVars;
+
+void CCfgVarBuffer::Init()
+{
+	m_CfgVarsCounter = 0;
+
+	// Count how many config variables there are
+	#define MACRO_CONFIG_INT(Name,ScriptName,Def,Min,Max,Flags,Desc) \
+	{ \
+		m_CfgVarsCounter++; \
+	}
+
+	#define MACRO_CONFIG_STR(Name,ScriptName,Len,Def,Flags,Desc) \
+	{ \
+		m_CfgVarsCounter++; \
+	}
+
+	#include "config_variables.h"
+	#include "game/variables.h"
+
+	#undef MACRO_CONFIG_INT
+	#undef MACRO_CONFIG_STR
+
+	m_CfgVars = new CfgVar[m_CfgVarsCounter];
+	int tCount = 0;
+
+	// read all config variables and save their information to m_CfgVars
+	#define MACRO_CFGVAR_SAVE_NAME(ScriptName) \
+	{ \
+		int i = 0; \
+		for ( ; i < 256; i++) \
+			if (#ScriptName[i] == 0) break; \
+		i++; \
+		m_CfgVars[tCount].m_pScriptName = new char[i]; \
+		m_CfgVars[tCount].m_ScriptNameLength = i; \
+		std::cout << "JDBG " << #ScriptName << " i: " << i << "\n"; \
+		str_copy(m_CfgVars[tCount].m_pScriptName, #ScriptName, i); \
+		m_CfgVars[tCount].m_pScriptName[i-1] = 0; \
+	}
+
+	#define MACRO_CONFIG_INT(Name,ScriptName,Def,Min,Max,Flags,Desc) \
+	{ \
+		m_CfgVars[tCount].m_Type = CFG_TYPE_INT; \
+		m_CfgVars[tCount].m_pIntValue = &g_Config.m_##Name; \
+		MACRO_CFGVAR_SAVE_NAME(ScriptName); \
+		tCount++; \
+	} 
+
+	#define MACRO_CONFIG_STR(Name,ScriptName,Len,Def,Flags,Desc) \
+	{ \
+		m_CfgVars[tCount].m_Type = CFG_TYPE_STR; \
+		m_CfgVars[tCount].m_pStrValue = g_Config.m_##Name; \
+		MACRO_CFGVAR_SAVE_NAME(ScriptName); \
+		tCount++; \
+	}
+
+	#include "config_variables.h"
+	#include "game/variables.h"
+
+	#undef MACRO_CONFIG_INT
+	#undef MACRO_CONFIG_STR
+}
+
+
+void CCfgVarBuffer::ConPrintCfg(CConsole* pConsole, const char *pCfgName)
+{
+	if (*pCfgName == 0) 
+	{
+		// print all config variables and their values
+		for (int i = 0; i < m_CfgVarsCounter; i++)
+		{
+			char lineBuff[512];
+			if (m_CfgVars[i].m_Type == CFG_TYPE_INT)
+				str_format(lineBuff, 512, "%s %i", m_CfgVars[i].m_pScriptName, *m_CfgVars[i].m_pIntValue);
+			else
+				str_format(lineBuff, 512, "%s %s", m_CfgVars[i].m_pScriptName, m_CfgVars[i].m_pStrValue);
+			pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "Console", lineBuff);
+		}
+		return;
+	}
+
+	// search for config vars that contain pCfgName and print them and their values
+	for (int i = 0; i < m_CfgVarsCounter; i++)
+	{
+		bool contains = false;
+		int m = 0;
+		for (int k = 0; k < m_CfgVars[i].m_ScriptNameLength; k++)
+		{
+			if (pCfgName[m] == m_CfgVars[i].m_pScriptName[k])
+				m++;
+			else 
+				m = 0;
+			if (pCfgName[m] == 0)
+			{
+				contains = true;
+				break;
+			}
+		}
+		if (!contains) continue;
+
+		char lineBuff[512];
+		if (m_CfgVars[i].m_Type == CFG_TYPE_INT)
+			str_format(lineBuff, 512, "%s %i", m_CfgVars[i].m_pScriptName, *m_CfgVars[i].m_pIntValue);
+		else
+			str_format(lineBuff, 512, "%s %s", m_CfgVars[i].m_pScriptName, m_CfgVars[i].m_pStrValue);
+		pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "Console", lineBuff);
+	}
+}
+
+/*
+// puts all config vars and their values inside a string
+// returns false if it runs out of memory
+bool CCfgVarBuffer::GetCfgStr(char *pStr, int StrSize)
+{
+	for (int i = 0; i < m_CfgVarsCounter; i++)
+	{
+		char lineBuff[512];
+		if (m_CfgVars[i].m_Type == CFG_TYPE_INT)
+			str_format(lineBuff, 512, "%s %i \n", m_CfgVars[i].m_pScriptName, *m_CfgVars[i].m_pIntValue);
+		else
+			str_format(lineBuff, 512, "%s %s \n", m_CfgVars[i].m_pScriptName, m_CfgVars[i].m_pStrValue);
+		int m = 0;
+		for ( ; m < 512; m++)
+			if (lineBuff[m] == 0) break;
+		if (StrSize-m <= 0)
+		{
+			*pStr = 0;
+			dbg_msg("GetCfgStr", "Error: out of memory");
+			return false;
+		}
+		for (int u = 0; u < m; u++)
+			pStr[u] = lineBuff[u];
+		StrSize -= m;
+		pStr += m;
+	}
+	*pStr = 0;
+	return true;
+}
+*/
+
+
+

--- a/src/engine/shared/cfgvar_buffer.h
+++ b/src/engine/shared/cfgvar_buffer.h
@@ -1,0 +1,40 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+/* Modifications Copyright 2019 The InfclassR (https://github.com/yavl/teeworlds-infclassR/) Authors */
+
+#ifndef ENGINE_SHARED_CFGVAR_BUFFER_H
+#define ENGINE_SHARED_CFGVAR_BUFFER_H
+
+#include <base/system.h>
+#include "console.h"
+
+class CCfgVarBuffer
+{
+
+	enum
+	{
+		CFG_TYPE_INT = 0,
+		CFG_TYPE_STR = 1
+	};
+
+	struct CfgVar
+	{
+		int m_Type;
+		char *m_pScriptName;
+		int m_ScriptNameLength;
+		int *m_pIntValue;
+		char *m_pStrValue;
+	};
+
+public:
+	static void Init();
+	static void ConPrintCfg(CConsole* pConsole, const char *pCfgName);
+
+private:
+	static CfgVar *m_CfgVars;
+	static int m_CfgVarsCounter;
+
+};
+
+
+#endif

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1,5 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+/* Modifications Copyright 2019 The InfclassR (https://github.com/yavl/teeworlds-infclassR/) Authors */
 #include <new>
 
 #include <base/math.h>
@@ -11,6 +12,10 @@
 #include "config.h"
 #include "console.h"
 #include "linereader.h"
+#include "cfgvar_buffer.h"
+
+#include <iostream>
+#include <string.h>
 
 // todo: rework this
 
@@ -483,14 +488,18 @@ void CConsole::ExecuteFile(const char *pFilename)
 bool CConsole::Con_Echo(IResult *pResult, void *pUserData)
 {
 	((CConsole*)pUserData)->Print(IConsole::OUTPUT_LEVEL_STANDARD, "Console", pResult->GetString(0));
-	
 	return true;
 }
 
 bool CConsole::Con_Exec(IResult *pResult, void *pUserData)
 {
 	((CConsole*)pUserData)->ExecuteFile(pResult->GetString(0));
-	
+	return true;
+}
+
+bool CConsole::Con_PrintCfg(IResult *pResult, void *pUserData)
+{
+	CCfgVarBuffer::ConPrintCfg(((CConsole*)pUserData), pResult->GetString(0));
 	return true;
 }
 
@@ -716,6 +725,8 @@ CConsole::CConsole(int FlagMask)
 	// register some basic commands
 	Register("echo", "r", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_Echo, this, "Echo the text");
 	Register("exec", "r", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_Exec, this, "Execute the specified file");
+
+	Register("printcfg", "?r", CFGFLAG_SERVER, Con_PrintCfg, this, "Prints config vars and their values");
 
 	Register("toggle", "sii", CFGFLAG_SERVER|CFGFLAG_CLIENT, ConToggle, this, "Toggle config value");
 	Register("+toggle", "sii", CFGFLAG_CLIENT, ConToggleStroke, this, "Toggle config value via keypress");

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -1,8 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+/* Modifications Copyright 2019 The InfclassR (https://github.com/yavl/teeworlds-infclassR/) Authors */
 #ifndef ENGINE_SHARED_CONSOLE_H
 #define ENGINE_SHARED_CONSOLE_H
 
+#include <base/math.h>
 #include <engine/console.h>
 #include "memheap.h"
 
@@ -54,6 +56,7 @@ class CConsole : public IConsole
 	static bool Con_Chain(IResult *pResult, void *pUserData);
 	static bool Con_Echo(IResult *pResult, void *pUserData);
 	static bool Con_Exec(IResult *pResult, void *pUserData);
+	static bool Con_PrintCfg(IResult *pResult, void *pUserData);
 	static bool ConToggle(IResult *pResult, void *pUser);
 	static bool ConToggleStroke(IResult *pResult, void *pUser);
 	static bool ConModCommandAccess(IResult *pResult, void *pUser);


### PR DESCRIPTION
I am still working on this and want to add more stuff.

What is working already is a new command called "printcfg"
You can type it in rcon console (F2) to get information about config vars.

For example "printcfg hero" outputs this for me:

> inf_hero_limit 10
> inf_enable_hero 1
> inf_hero_flag_indicator 0

"printcfg map" outputs this for me:

> sv_maprotation infc_skull infc_warehouse infc_damascus infc_hardcorepit
> sv_rounds_per_map 8
> sv_mapupdaterate 5
> sv_map infc_hardcorepit
> inf_map_window 15
> inf_maprotation_random 1
> inf_min_rounds_map_vote 0
> inf_min_player_percent_map_vote 100
> inf_min_player_number_map_vote 3
>  sv_maprotation infc_skull infc_warehouse infc_damascus infc_hardcorepit
> sv_rounds_per_map 8
> sv_mapupdaterate 5

