### PR TITLE
Log players online + bug fixes (infclass-stats)

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2704,12 +2704,6 @@ void CCharacter::Die(int Killer, int Weapon)
 	m_pPlayer->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()/2;
 	int ModeSpecial = GameServer()->m_pController->OnCharacterDeath(this, GameServer()->m_apPlayers[Killer], Weapon);
 
-	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "kill killer='%d:%s' victim='%d:%s' weapon=%d special=%d",
-		Killer, Server()->ClientName(Killer),
-		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial);
-	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
-
 	// send the kill message
 	CNetMsg_Sv_KillMsg Msg;
 	Msg.m_Killer = Killer;
@@ -2918,6 +2912,12 @@ bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon, int Mode)
 			}
 		}
 		
+		char aBuf[256];
+		str_format(aBuf, sizeof(aBuf), "kill killer='%s' victim='%s' weapon=%d",
+			Server()->ClientName(From),
+			Server()->ClientName(m_pPlayer->GetCID()), Weapon);
+		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
 		CNetMsg_Sv_KillMsg Msg;
 		Msg.m_Killer = From;
 		Msg.m_Victim = m_pPlayer->GetCID();

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2197,10 +2197,6 @@ void CCharacter::Tick()
 					m_pPlayer->SetClass(NewClass);
 					m_pPlayer->SetOldClass(NewClass);
 					
-					char aBuf[256];
-					str_format(aBuf, sizeof(aBuf), "choose_class player='%s' class='%d'", Server()->ClientName(m_pPlayer->GetCID()), NewClass);
-					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
-					
 					if(Bonus)
 						IncreaseArmor(10);
 				}

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -24,6 +24,7 @@ CGameControllerMOD::CGameControllerMOD(class CGameContext *pGameServer)
 	m_GrowingMap = new int[m_MapWidth*m_MapHeight];
 	
 	m_InfectedStarted = false;
+	m_ReportTick = Server()->TickSpeed() * 60;
 	
 	for(int j=0; j<m_MapHeight; j++)
 	{
@@ -186,7 +187,7 @@ void CGameControllerMOD::Tick()
 	GetPlayerCounter(-1, NumHumans, NumInfected, NumFirstInfected);
 	
 	m_InfectedStarted = false;
-	
+
 	//If the game can start ...
 	if(m_GameOverTick == -1 && NumHumans + NumInfected >= g_Config.m_InfMinPlayers)
 	{
@@ -431,6 +432,30 @@ void CGameControllerMOD::Tick()
 			m_pHeroFlag->Show();
 		
 		m_RoundStartTick = Server()->Tick();
+	}
+
+	if (m_ReportTick <= 0)
+	{
+		CPlayerIterator<PLAYERITER_ALL> Iter(GameServer()->m_apPlayers);
+		
+		dynamic_string Buffer;
+
+		Buffer.append("online list=[");
+		if (Iter.Next())
+		{
+			Buffer.append(Server()->ClientName(Iter.Player()->GetCID()));
+		}
+
+		while(Iter.Next())
+		{
+			Buffer.append(", ");
+			Buffer.append(Server()->ClientName(Iter.Player()->GetCID()));
+		}
+		Buffer.append("]");
+		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", Buffer.buffer());
+		m_ReportTick = Server()->TickSpeed() * 60;
+	} else {
+		m_ReportTick--;
 	}
 }
 

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -43,6 +43,7 @@ private:
 private:	
 	int m_MapWidth;
 	int m_MapHeight;
+	int m_ReportTick; // print players online to console
 	int* m_GrowingMap;
 	bool m_ExplosionStarted;
 	

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -752,6 +752,10 @@ void CPlayer::SetClass(int newClass)
 	{
 		m_pCharacter->SetClass(newClass);
 	}
+
+	char aBuf[256];
+	str_format(aBuf, sizeof(aBuf), "choose_class player='%s' class='%d'", Server()->ClientName(m_ClientID), newClass);
+	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
 }
 
 int CPlayer::GetOldClass()


### PR DESCRIPTION
I'm trying to release a 1.0 version for infclass-stats soon and needed to fix some final things in the log statements:

* Instead of calling `status` all the time on a new round a list of all players online is printed in intervals
* Bug fix where zombie kills were not logged
* Bug fix where not picking any class and a random class is chosen was not logged