### PR TITLE
added print_idcount command to print how many ids are currently used

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -197,6 +197,28 @@ void CSnapIDPool::FreeID(int ID)
 	}
 }
 
+int CSnapIDPool::GetIDCount()
+{
+	int Count = 0;
+	for(int i = 0; i < MAX_IDS; i++)
+	{
+		if (m_aIDs[i].m_State == 1)
+			Count++;
+	}
+	return Count;
+}
+
+bool CServer::ConGetIDCount(IConsole::IResult *pResult, void *pUser)
+{
+	CServer* pThis = (CServer*)pUser;
+	int IDCount = pThis->m_IDPool.GetIDCount();
+	int IDPercent = (int)(((float)IDCount/pThis->m_IDPool.GetMaxIDs())*100);
+	char aBuff[128];
+	str_format(aBuff, sizeof(aBuff), "IDCount: %i - InPercent: %i%%", IDCount, IDPercent);
+	pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "Server", aBuff);
+	return true;
+}
+
 void CServerBan::InitServerBan(IConsole *pConsole, IStorage *pStorage, CServer* pServer)
 {
 	CNetBan::Init(pConsole, pStorage);
@@ -2728,6 +2750,7 @@ void CServer::RegisterCommands()
 	Console()->Register("inf_add_sqlserver", "ssssssi?i", CFGFLAG_SERVER, ConAddSqlServer, this, "add a sqlserver");
 	Console()->Register("inf_list_sqlservers", "s", CFGFLAG_SERVER, ConDumpSqlServers, this, "list all sqlservers readservers = r, writeservers = w");
 #endif
+	Console()->Register("print_idcount", "", CFGFLAG_SERVER, ConGetIDCount, this, "prints how many entity ids are currently used - useful for debugging");
 /* INFECTION MODIFICATION END *****************************************/
 
 	// register console commands in sub parts

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -46,6 +46,8 @@ public:
 	int NewID();
 	void TimeoutIDs();
 	void FreeID(int ID);
+	int GetIDCount();
+	int GetMaxIDs() { return MAX_IDS; }
 };
 
 
@@ -290,6 +292,7 @@ public:
 /* DDNET MODIFICATION START *******************************************/
 	static bool ConAddSqlServer(IConsole::IResult *pResult, void *pUserData);
 	static bool ConDumpSqlServers(IConsole::IResult *pResult, void *pUserData);
+	static bool ConGetIDCount(IConsole::IResult *pResult, void *pUser);
 
 	static void CreateTablesThread(void *pData);
 /* DDNET MODIFICATION END *********************************************/


### PR DESCRIPTION
This allows you type "print_idcount" into rcon console and the server prints how many entity ids are currently used.
We need this to better debug issues related to entity ids, like #109 

The output will look like this:

> IDCount: 53 - InPercent: 0%

Percent shows how many percent of all ids are currently used, if it reaches 100% it might crash