### PR TITLE
Revert: Log players online, fix bug where not all kills where logged (infclass-stats)

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2742,6 +2742,12 @@ void CCharacter::Die(int Killer, int Weapon)
 	m_pPlayer->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()/2;
 	int ModeSpecial = GameServer()->m_pController->OnCharacterDeath(this, GameServer()->m_apPlayers[Killer], Weapon);
 
+	char aBuf[256];
+	str_format(aBuf, sizeof(aBuf), "kill killer='%s' victim='%s' weapon=%d",
+		Server()->ClientName(Killer),
+		Server()->ClientName(m_pPlayer->GetCID()), Weapon);
+	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
 	// send the kill message
 	CNetMsg_Sv_KillMsg Msg;
 	Msg.m_Killer = Killer;

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -24,7 +24,6 @@ CGameControllerMOD::CGameControllerMOD(class CGameContext *pGameServer)
 	m_GrowingMap = new int[m_MapWidth*m_MapHeight];
 	
 	m_InfectedStarted = false;
-	m_ReportTick = Server()->TickSpeed() * 60;
 	
 	for(int j=0; j<m_MapHeight; j++)
 	{
@@ -418,30 +417,6 @@ void CGameControllerMOD::Tick()
 		GameServer()->DisableTargetToKill();
 		
 		m_RoundStartTick = Server()->Tick();
-	}
-
-	if (m_ReportTick <= 0)
-	{
-		CPlayerIterator<PLAYERITER_ALL> Iter(GameServer()->m_apPlayers);
-		
-		dynamic_string Buffer;
-
-		Buffer.append("online list=[");
-		if (Iter.Next())
-		{
-			Buffer.append(Server()->ClientName(Iter.Player()->GetCID()));
-		}
-
-		while(Iter.Next())
-		{
-			Buffer.append(", ");
-			Buffer.append(Server()->ClientName(Iter.Player()->GetCID()));
-		}
-		Buffer.append("]");
-		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", Buffer.buffer());
-		m_ReportTick = Server()->TickSpeed() * 60;
-	} else {
-		m_ReportTick--;
 	}
 }
 

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -43,7 +43,6 @@ private:
 private:	
 	int m_MapWidth;
 	int m_MapHeight;
-	int m_ReportTick; // print players online to console
 	int* m_GrowingMap;
 	bool m_ExplosionStarted;
 	


### PR DESCRIPTION
I determined using a comma-separated list of player names just causes all kinds of issues with parsing and revert back to polling the player count via the `rcon` command. This may cause a lot of lines the sort of:
```
(#00) I...            : [antispoof=0] [login=0] [level=0] [ip=(...)]
(#01) g... : [antispoof=1] [login=0] [level=0] [ip(...)]
(#02) T...    : [antispoof=1] [login=0] [level=0] [ip=(...)]
(#03) T...   : [antispoof=1] [login=0] [level=0] [ip=(...)]
(#04) N...            : [antispoof=1] [login=1] [level=0] [ip=(...)]
(#05) g...      : [antispoof=0] [login=0] [level=0] [ip=(...)]
(#06) B..             : [antispoof=1] [login=1] [level=0] [ip=(...)]
(#07) н...     : [antispoof=0] [login=0] [level=0] [ip=(...)]
```

but unless this may be a problem this fix should suffice.

Additionally not all kills -but just zombie kills - were logged and able to be picked up. This is was fixed as well