### PR TITLE
Implement persistent muting via /mute

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -22,6 +22,7 @@ enum
 };
 
 /* INFECTION MODIFICATION START ***************************************/
+bool CGameContext::m_ClientMuted[MAX_CLIENTS][MAX_CLIENTS];
 
 void CGameContext::OnSetAuthed(int ClientID, int Level)
 {
@@ -40,6 +41,13 @@ void CGameContext::Construct(int Resetting)
 	{
 		m_apPlayers[i] = 0;
 		m_aHitSoundState[i] = 0;
+	}
+
+	if(Resetting==NO_RESET) // first init
+	{
+		for(int i = 0; i < MAX_CLIENTS; i++)
+			for(int j = 0; j < MAX_CLIENTS; j++)
+				CGameContext::m_ClientMuted[i][j] = false;
 	}
 
 	m_pController = 0;
@@ -825,7 +833,15 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText)
 		Msg.m_Team = 0;
 		Msg.m_ClientID = ChatterClientID;
 		Msg.m_pMessage = pText;
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
+
+		// send to the clients that did not mute chatter
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			if(m_apPlayers[i] && !CGameContext::m_ClientMuted[i][ChatterClientID])
+			{
+				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, i);
+			}
+		}
 	}
 	else
 	{
@@ -1509,7 +1525,15 @@ void CGameContext::OnClientDrop(int ClientID, int Type, const char *pReason)
 	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "leave player='%d:%s'", ClientID, Server()->ClientName(ClientID));
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
-
+	
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		// remove everyone this player had muted
+		CGameContext::m_ClientMuted[ClientID][i] = false;
+		
+		// reset mutes for everyone that muted this player
+		CGameContext::m_ClientMuted[i][ClientID] = false;
+	}
 	//Count players
 	CountActivePlayers();
 	CountSpectators();
@@ -1815,6 +1839,10 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			else if(str_comp_num(pMsg->m_pMessage, "/w ", 3) == 0)
 			{
 				PrivateMessage(pMsg->m_pMessage+3, ClientID, (Team != CGameContext::CHAT_ALL));
+			}
+			else if(str_comp_num(pMsg->m_pMessage, "/mute ", 6) == 0)
+			{
+				MutePlayer(pMsg->m_pMessage+6, ClientID);
 			}
 			else if(pMsg->m_pMessage[0] == '/' || pMsg->m_pMessage[0] == '\\')
 			{
@@ -3286,6 +3314,23 @@ bool CGameContext::PrivateMessage(const char* pStr, int ClientID, bool TeamChat)
 	return true;
 }
 
+void CGameContext::MutePlayer(const char* pStr, int ClientID)
+{
+	for(int i=0; i<MAX_CLIENTS; i++)
+	{
+		if(m_apPlayers[i] && str_comp(Server()->ClientName(i), pStr) == 0)
+		{
+			CGameContext::m_ClientMuted[ClientID][i] = !CGameContext::m_ClientMuted[ClientID][i];
+			
+			if(CGameContext::m_ClientMuted[ClientID][i])
+				SendChatTarget(ClientID, "Player muted. Mute will persist until you or the muted player disconnects.");
+			else
+				SendChatTarget(ClientID, "Player unmuted. You can see his messages again.");
+			break;
+		}
+	}
+}
+
 #ifdef CONF_SQL
 
 bool CGameContext::ConRegister(IConsole::IResult *pResult, void *pUserData)
@@ -3908,6 +3953,21 @@ bool CGameContext::ConHelp(IConsole::IResult *pResult, void *pUserData)
 			
 			pSelf->SendMOTD(ClientID, Buffer.buffer());
 		}
+		else if(str_comp_nocase(pHelpPage, "mute") == 0)
+		{
+			Buffer.append("~~ ");
+			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("Persistent player mute")); 
+			Buffer.append(" ~~\n\n");
+			Buffer.append("\n\n");
+			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("Use “/mute <PlayerName>” to mute this player."), NULL);
+			Buffer.append("\n\n");
+			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("Unlike a client mute this will persist between map changes and wears off when either you or the muted player disconnects."), NULL);
+			Buffer.append("\n\n");
+			pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, _("Example: “/mute nameless tee”"), NULL);
+			Buffer.append("\n\n");
+			
+			pSelf->SendMOTD(ClientID, Buffer.buffer());
+		}
 		else if(str_comp_nocase(pHelpPage, "taxi") == 0)
 		{
 			Buffer.append("~~ ");
@@ -4083,7 +4143,7 @@ bool CGameContext::ConCmdList(IConsole::IResult *pResult, void *pUserData)
 	Buffer.append(" ~~\n\n");
 	pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, "/antiping, /alwaysrandom, /customskin, /help, /info, /language", NULL);
 	Buffer.append("\n\n");
-	pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, "/msg", NULL);
+	pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, "/msg, /mute", NULL);
 	Buffer.append("\n\n");
 #ifdef CONF_SQL
 	pSelf->Server()->Localization()->Format_L(Buffer, pLanguage, "/register, /login, /logout, /setemail", NULL);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3325,7 +3325,7 @@ void CGameContext::MutePlayer(const char* pStr, int ClientID)
 			if(CGameContext::m_ClientMuted[ClientID][i])
 				SendChatTarget(ClientID, "Player muted. Mute will persist until you or the muted player disconnects.");
 			else
-				SendChatTarget(ClientID, "Player unmuted. You can see his messages again.");
+				SendChatTarget(ClientID, "Player unmuted. You can see their messages again.");
 			break;
 		}
 	}

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -282,7 +282,8 @@ private:
 	static bool ConCmdList(IConsole::IResult *pResult, void *pUserData);
 	static bool ConWitch(IConsole::IResult *pResult, void *pUserData);
 	bool PrivateMessage(const char* pStr, int ClientID, bool TeamChat);
-
+	void MutePlayer(const char* pStr, int ClientID);
+	
 	void OnCallVote(void *pRawMsg, int ClientID);
 	int IsMapVote(const char *pVoteCommand);
 	void GetMapNameFromCommand(char* pMapName, const char *pCommand);
@@ -320,6 +321,7 @@ private:
 	int m_VoteLanguageTick[MAX_CLIENTS];
 	char m_VoteLanguage[MAX_CLIENTS][16];
 	int m_VoteBanClientID;
+	static bool m_ClientMuted[MAX_CLIENTS][MAX_CLIENTS]; // m_ClientMuted[i][j]: i muted j
 	
 	class CBroadcastState
 	{


### PR DESCRIPTION
Some people playing this game need to grow the fuck up but because this may still take a decade until they may even come close to puberty i can finally mute their sorry ass and not bother until either me or them disconnects.

Mutes are stored in a static two-dimensional array of clientIDs that persists between new gamecontexts (created for each new map loaded afaik). So when either the muter or muted disconnects that row+column is cleared again.