### PR TITLE
add teamchat to /mute too

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -862,7 +862,7 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText)
 				int PlayerTeam = (m_apPlayers[i]->IsZombie() ? CGameContext::CHAT_RED : CGameContext::CHAT_BLUE );
 				if(m_apPlayers[i]->GetTeam() == TEAM_SPECTATORS) PlayerTeam = CGameContext::CHAT_SPEC;
 				
-				if(PlayerTeam == Team)
+				if(PlayerTeam == Team && !CGameContext::m_ClientMuted[i][ChatterClientID])
 				{
 					Server()->SendPackMsg(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, i);
 				}


### PR DESCRIPTION
Although spamming to teamchat is admin-muttable offense on my server, there should be a way to player-mute someone, because admin cannot read both teamchats and is not always online.