### PR TITLE
Spectators do not join the game after round start

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -22,7 +22,10 @@ enum
 };
 
 /* INFECTION MODIFICATION START ***************************************/
+
+// Attributes persisting between gamecontext creation and destruction
 bool CGameContext::m_ClientMuted[MAX_CLIENTS][MAX_CLIENTS];
+std::vector<int> CGameContext::spectators_id;
 
 void CGameContext::OnSetAuthed(int ClientID, int Level)
 {
@@ -4554,17 +4557,17 @@ void CGameContext::List(int ClientID, const char* filter)
 void CGameContext::AddSpectatorCID(int ClientID)
 {
 	Server()->RemoveMapVotesForID(ClientID);
-	auto& vec = spectators_id;
+	auto& vec = CGameContext::spectators_id;
 	if(!(std::find(vec.begin(), vec.end(), ClientID) != vec.end()))
 		vec.push_back(ClientID);
 }
 
 void CGameContext::RemoveSpectatorCID(int ClientID) {
-	auto& vec = spectators_id;
+	auto& vec = CGameContext::spectators_id;
 	vec.erase(std::remove(vec.begin(), vec.end(), ClientID), vec.end());
 }
 
 bool CGameContext::IsSpectatorCID(int ClientID) {
-	auto& vec = spectators_id;
+	auto& vec = CGameContext::spectators_id;
 	return std::find(vec.begin(), vec.end(), ClientID) != vec.end();
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -148,7 +148,7 @@ public:
 	int GetHumanCount();
 	void CountZombies();
 	int GetZombieCount();
-	std::vector<int> spectators_id; //spectators vector
+	static std::vector<int> spectators_id; //spectators vector
 	int m_NbActivePlayers;
 	int m_NbSpectators;
 	int m_NbHumans;


### PR DESCRIPTION
Ill quote fluffy here for context too lazy right now
```
@Armadillo do you still have exams?
I need to fix a bug that was introduced by big Getter Setter commit.

After round start all spectators join the game automatically and won't stay spectators anymore. It seems that one spawn related method is not working correctly.
Maybe you can help me finding it.

```

Tested by spectating and then using skip_map